### PR TITLE
Add dynamic configuration and extend user service API

### DIFF
--- a/UserManager/include/database/userDBManager.h
+++ b/UserManager/include/database/userDBManager.h
@@ -31,6 +31,11 @@ namespace UberBackend
         bool deleteUserById(int id);
 
         [[nodiscard]] nlohmann::json searchUsersByUsername(const std::string &username);
+        [[nodiscard]] nlohmann::json getUsersPaginated(int offset, int limit);
+        [[nodiscard]] nlohmann::json getUserStats();
+
+        bool usernameExists(const std::string &username);
+        bool emailExists(const std::string &email);
 
     private:
         SingletonLogger &logger_;

--- a/UserManager/include/services/routeHandler/routeHandler.h
+++ b/UserManager/include/services/routeHandler/routeHandler.h
@@ -22,7 +22,7 @@ namespace UberBackend
         RouteHandler(std::shared_ptr<SharedDatabase> db);
         ~RouteHandler();
 
-        void handleNewUser(std::shared_ptr<User> user);
+        bool handleNewUser(std::shared_ptr<User> user);
         nlohmann::json handleUserLogin(std::string &username);
 
         // Extended CRUD operations
@@ -30,6 +30,7 @@ namespace UberBackend
         bool handleUpdateUser(const std::string &userId, const nlohmann::json &data);
         bool handleDeleteUser(const std::string &userId);
         nlohmann::json handleGetAllUsers();
+        nlohmann::json handleGetUsersPaginated(int offset, int limit);
 
         // PATCH operations
         bool handlePasswordUpdate(const std::string &userId, const std::string &oldPwd, const std::string &newPwd);
@@ -37,6 +38,11 @@ namespace UberBackend
 
         // Search
         nlohmann::json searchUsersByUsername(const std::string &username);
+        nlohmann::json checkUserAvailability(const std::string &username, const std::string &email);
+
+        // Service telemetry
+        nlohmann::json getUserStats();
+        nlohmann::json getHealthStatus();
 
     private:
         std::shared_ptr<UserDBManager> userDBManager_;

--- a/UserManager/src/main.cpp
+++ b/UserManager/src/main.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <iostream>
 
 #include "../include/server.h"
@@ -10,22 +11,30 @@ using namespace UberBackend;
 auto &logger_ = SingletonLogger::instance("log/UserServerLog.txt");
 
 // Creating a unique pointer for the Server instance
-std::unique_ptr<Server> server_ = std::make_unique<Server>("UserManager",
-                                                           UberUtils::CONFIG::USER_MANAGER_HOST,
-                                                           UberUtils::CONFIG::USER_MANAGER_USERNAME,
-                                                           UberUtils::CONFIG::USER_MANAGER_PASSWORD,
-                                                           UberUtils::CONFIG::USER_MANAGER_DATABASE_NAME,
-                                                           UberUtils::CONFIG::USER_MANAGER_DATABASE_PORT);
+std::unique_ptr<Server> server_;
 
 // Staring the application
 void startApplication()
 {
     logger_.logMeta(SingletonLogger::INFO, "Starting Uber User Manager Server......", __FILE__, __LINE__, __func__);
-    std::string path = "../../UserManager/sql_scripts/database_init.sql";
+    const auto sourceDir = std::filesystem::path(__FILE__).parent_path();
+    const auto projectRoot = (sourceDir / "../../").lexically_normal();
+
+    const auto envPath = (projectRoot / ".env").lexically_normal();
+    UberBackend::ConfigManager::instance().loadFromFile(envPath.string());
 
     logger_.logMeta(SingletonLogger::DEBUG, "creating server instance for user Manager", __FILE__, __LINE__, __func__);
 
-    server_->initiateDatabase(path);
+    server_ = std::make_unique<Server>("UserManager",
+                                       UberUtils::CONFIG::getUserManagerHost(),
+                                       UberUtils::CONFIG::getUserManagerUsername(),
+                                       UberUtils::CONFIG::getUserManagerPassword(),
+                                       UberUtils::CONFIG::getUserManagerDatabase(),
+                                       UberUtils::CONFIG::getUserManagerDatabasePort());
+
+    const auto initScript = (projectRoot / "UserManager/sql_scripts/database_init.sql").lexically_normal();
+
+    server_->initiateDatabase(initScript.string());
     server_->createHttpServers();
     logger_.logMeta(SingletonLogger::DEBUG, "run : server_->startHttpServers();", __FILE__, __LINE__, __func__);
     server_->startHttpServers();
@@ -35,13 +44,21 @@ void startApplication()
 void stopApplication()
 {
     logger_.logMeta(SingletonLogger::INFO, "Stoping Uber User Manager Server......", __FILE__, __LINE__, __func__);
+    if (!server_)
+    {
+        logger_.logMeta(SingletonLogger::WARNING, "Server instance was not initialised before stop call", __FILE__, __LINE__, __func__);
+        return;
+    }
+
     server_->stopHttpServers();
 
-    std::string path = "../../UserManager/sql_scripts/database_del.sql";
+    const auto sourceDir = std::filesystem::path(__FILE__).parent_path();
+    const auto projectRoot = (sourceDir / "../../").lexically_normal();
+    const auto dropScript = (projectRoot / "UserManager/sql_scripts/database_del.sql").lexically_normal();
     logger_.logMeta(SingletonLogger::INFO, "distroying server instance for user Manager", __FILE__, __LINE__, __func__);
 
     // Distorying the database - this will drop all the tables and data just for debugging purposes
-    server_->distoryDatabase(path);
+    server_->distoryDatabase(dropScript.string());
 }
 
 int main()

--- a/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
+++ b/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
@@ -1,4 +1,11 @@
+#include <algorithm>
+#include <optional>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
 #include "../include/services/httpHandler/servers/httpUserServer.h"
+#include "../../../../sharedUtils/include/config.h"
 
 using namespace UberBackend;
 using namespace utils;
@@ -7,236 +14,428 @@ HttpUserServer::HttpUserServer(const std::string &name,
                                const std::string &host,
                                int port,
                                std::shared_ptr<SharedDatabase> db)
-    : SharedHttpServer(name, host, port, db), jwt_("your_super_secret_key")
+    : SharedHttpServer(name, host, port, db), jwt_(UberUtils::CONFIG::getJwtSecret())
 {
     routHandler_ = std::make_shared<RouteHandler>(db);
 }
 
 void HttpUserServer::createServerMethods()
 {
-    server_->Post("/login", [this](const httplib::Request &req, httplib::Response &res)
-                  {
-        std::string body = req.body;
-        auto jsonData = Json::parse(body);
+    using nlohmann::json;
 
-        if (jsonData.contains("username") && jsonData.contains("password")) {
-            std::string username = jsonData["username"];
-            std::string passwordInput = jsonData["password"];
+    auto respondJson = [this](httplib::Response &res, const json &payload, int status = 200)
+    {
+        res.status = status;
+        res.set_content(payload.dump(), "application/json");
+    };
 
-            logger_.logMeta(SingletonLogger::INFO, "Received login request", __FILE__, __LINE__, __func__);
-
-            auto userData = routHandler_->handleUserLogin(username);
-
-            logger_.logMeta(SingletonLogger::DEBUG, "User Data: " + userData.dump(), __FILE__, __LINE__, __func__);
-
-            if (!userData.empty()) {
-                std::string storedHash = userData["password_hash"];
-                logger_.logMeta(SingletonLogger::DEBUG, "password : " + passwordInput , __FILE__, __LINE__, __func__);
-                std::string hashedInput = algorithms::hashComputation(algorithms::toBinary(passwordInput));
-                logger_.logMeta(SingletonLogger::DEBUG, "storedHash: " + storedHash , __FILE__, __LINE__, __func__);
-                logger_.logMeta(SingletonLogger::DEBUG, "hashedInput: " + hashedInput, __FILE__, __LINE__, __func__);
-
-                if (storedHash == hashedInput) {
-                    std::string userId = userData["user_id"];
-                    std::string token = jwt_.generateToken(userId);
-
-                    logger_.logMeta(SingletonLogger::INFO, "Login successful, token generated", __FILE__, __LINE__, __func__);
-
-                    nlohmann::json responseJson;
-                    responseJson["token"] = token;
-                    logger_.logMeta(SingletonLogger::DEBUG, "JWT TOKEN: " + token, __FILE__, __LINE__, __func__);
-
-                    res.set_content(responseJson.dump(), "application/json");
-                    return;
-                } else {
-                    logger_.logMeta(SingletonLogger::ERROR, "Password mismatch", __FILE__, __LINE__, __func__);
-                }
-            } else {
-                logger_.logMeta(SingletonLogger::ERROR, "User not found", __FILE__, __LINE__, __func__);
-            }
-        } else {
-            logger_.logMeta(SingletonLogger::ERROR, "Invalid login data", __FILE__, __LINE__, __func__);
+    auto parseBody = [this, respondJson](const httplib::Request &req, httplib::Response &res) -> std::optional<json>
+    {
+        if (req.body.empty())
+        {
+            logger_.logMeta(SingletonLogger::ERROR, "Empty request body received", __FILE__, __LINE__, __func__);
+            respondJson(res, json{{"error", "Empty request body"}}, 400);
+            return std::nullopt;
         }
 
-        res.status = 401;
-        res.set_content(R"({"error": "Invalid username or password"})", "application/json"); });
+        json jsonData = json::parse(req.body, nullptr, false);
+        if (jsonData.is_discarded())
+        {
+            logger_.logMeta(SingletonLogger::ERROR, "Failed to parse JSON body", __FILE__, __LINE__, __func__);
+            respondJson(res, json{{"error", "Invalid JSON payload"}}, 400);
+            return std::nullopt;
+        }
 
-    server_->Post("/signup", [this](const httplib::Request &req, httplib::Response &res)
-                  {
-    std::string body = req.body;
-    auto jsonData = Json::parse(body);
+        return jsonData;
+    };
 
-    if (jsonData.contains("firstName") &&
-        jsonData.contains("middleName") &&
-        jsonData.contains("lastName") &&
-        jsonData.contains("mobileNumber") &&
-        jsonData.contains("address") &&
-        jsonData.contains("email") &&
-        jsonData.contains("username") &&
-        jsonData.contains("password") &&
-        jsonData.contains("role"))
+    auto sanitizeToken = [](std::string token)
     {
-        logger_.logMeta(SingletonLogger::INFO, "Received signup data successfully", __FILE__, __LINE__, __func__);
+        const std::string bearerPrefix = "Bearer ";
+        if (token.rfind(bearerPrefix, 0) == 0)
+        {
+            token.erase(0, bearerPrefix.size());
+        }
+        return token;
+    };
 
-        std::string firstName = jsonData["firstName"];
-        std::string middleName = jsonData["middleName"];
-        std::string lastName = jsonData["lastName"];
-        std::string mobileNumber = jsonData["mobileNumber"];
-        std::string address = jsonData["address"];
-        std::string email = jsonData["email"];
-        std::string username = jsonData["username"];
-        std::string passwordHash = algorithms::hashComputation(algorithms::toBinary(jsonData["password"]));
-        std::string role = jsonData["role"];
+    auto parsePaginationParam = [](const httplib::Request &req, const char *param, int defaultValue) -> int
+    {
+        if (!req.has_param(param))
+        {
+            return defaultValue;
+        }
+
+        try
+        {
+            return std::stoi(req.get_param_value(param));
+        }
+        catch (...)
+        {
+            return defaultValue;
+        }
+    };
+
+    server_->Post("/login", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
+    {
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+        const auto &jsonData = *jsonDataOpt;
+
+        if (!jsonData.contains("username") || !jsonData.contains("password"))
+        {
+            respondJson(res, json{{"error", "Missing username or password"}}, 400);
+            return;
+        }
+
+        std::string username = jsonData.at("username").get<std::string>();
+        std::string passwordInput = jsonData.at("password").get<std::string>();
+
+        logger_.logMeta(SingletonLogger::INFO, "Received login request", __FILE__, __LINE__, __func__);
+
+        auto userData = routHandler_->handleUserLogin(username);
+        logger_.logMeta(SingletonLogger::DEBUG, "User Data: " + userData.dump(), __FILE__, __LINE__, __func__);
+
+        if (!userData.empty())
+        {
+            std::string storedHash = userData.value("password_hash", std::string{});
+            std::string hashedInput = algorithms::hashComputation(algorithms::toBinary(passwordInput));
+
+            if (storedHash == hashedInput)
+            {
+                std::string userId = userData.value("user_id", std::string{});
+                std::string token = jwt_.generateToken(userId);
+
+                logger_.logMeta(SingletonLogger::INFO, "Login successful, token generated", __FILE__, __LINE__, __func__);
+
+                respondJson(res, json{{"token", token}, {"user_id", userId}});
+                return;
+            }
+        }
+
+        logger_.logMeta(SingletonLogger::ERROR, "Invalid credentials supplied", __FILE__, __LINE__, __func__);
+        respondJson(res, json{{"error", "Invalid username or password"}}, 401);
+    });
+
+    server_->Post("/signup", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
+    {
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+        const auto &jsonData = *jsonDataOpt;
+
+        const std::vector<std::string> requiredFields = {
+            "firstName", "middleName", "lastName", "mobileNumber", "address", "email", "username", "password", "role"
+        };
+
+        std::vector<std::string> missingFields;
+        for (const auto &field : requiredFields)
+        {
+            if (!jsonData.contains(field) || jsonData.at(field).is_null())
+            {
+                missingFields.push_back(field);
+                continue;
+            }
+
+            const auto &value = jsonData.at(field);
+            if (!value.is_string() || value.get<std::string>().empty())
+            {
+                missingFields.push_back(field);
+            }
+        }
+
+        if (!missingFields.empty())
+        {
+            respondJson(res, json{{"error", "Missing required fields"}, {"fields", missingFields}}, 400);
+            return;
+        }
+
+        std::string email = jsonData.at("email").get<std::string>();
+        std::string username = jsonData.at("username").get<std::string>();
+
+        auto availability = routHandler_->checkUserAvailability(username, email);
+        if (availability.value("usernameTaken", false) || availability.value("emailTaken", false))
+        {
+            respondJson(res, json{{"error", "User already exists"}, {"details", availability}}, 409);
+            return;
+        }
+
+        std::string passwordHash = algorithms::hashComputation(algorithms::toBinary(jsonData.at("password").get<std::string>()));
 
         auto user = std::make_shared<User>(
-            firstName,
-            middleName,
-            lastName,
-            "",                 // countryCode - not yet provided
-            mobileNumber,
-            address,
+            jsonData.at("firstName").get<std::string>(),
+            jsonData.at("middleName").get<std::string>(),
+            jsonData.at("lastName").get<std::string>(),
+            jsonData.value("countryCode", std::string{}),
+            jsonData.at("mobileNumber").get<std::string>(),
+            jsonData.at("address").get<std::string>(),
             email,
             username,
             passwordHash,
-            role,
-            "",                 // preferredLanguage
-            "",                 // currency
-            ""                  // country
+            jsonData.at("role").get<std::string>(),
+            jsonData.value("preferredLanguage", std::string{}),
+            jsonData.value("currency", std::string{}),
+            jsonData.value("country", std::string{})
         );
 
         logger_.logMeta(SingletonLogger::INFO, "Calling handleNewUser()", __FILE__, __LINE__, __func__);
 
-        routHandler_->handleNewUser(user);
+        if (routHandler_->handleNewUser(user))
+        {
+            respondJson(res, json{{"message", "Signup successful"}}, 201);
+        }
+        else
+        {
+            respondJson(res, json{{"error", "Signup unsuccessful"}}, 409);
+        }
+    });
 
-        res.set_content("Signup successful", "text/plain");
-    }
-    else
+    server_->Get(R"(/user/(\d+))", [this, respondJson](const httplib::Request &req, httplib::Response &res)
     {
-        logger_.logMeta(SingletonLogger::ERROR, "Signup data missing fields", __FILE__, __LINE__, __func__);
-        res.set_content("Signup unsuccessful - missing fields", "text/plain");
-    } });
-
-    // GET /user/:id
-    server_->Get(R"(/user/(\d+))", [this](const httplib::Request &req, httplib::Response &res)
-                 {
         std::string userId = req.matches[1];
         logger_.logMeta(SingletonLogger::INFO, "GET /user/" + userId, __FILE__, __LINE__, __func__);
 
         auto userJson = routHandler_->handleGetUserById(userId);
-        if (!userJson.empty()) {
-            res.set_content(userJson.dump(), "application/json");
-        } else {
-            res.status = 404;
-            res.set_content(R"({"error": "User not found"})", "application/json");
-        } });
+        if (!userJson.empty())
+        {
+            respondJson(res, userJson);
+        }
+        else
+        {
+            respondJson(res, json{{"error", "User not found"}}, 404);
+        }
+    });
 
-    // PUT /user/:id
-    server_->Put(R"(/user/(\d+))", [this](const httplib::Request &req, httplib::Response &res)
-                 {
+    server_->Put(R"(/user/(\d+))", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
+    {
         std::string userId = req.matches[1];
         logger_.logMeta(SingletonLogger::INFO, "PUT /user/" + userId, __FILE__, __LINE__, __func__);
 
-        auto jsonData = Json::parse(req.body);
-        bool success = routHandler_->handleUpdateUser(userId, jsonData);
-        if (success) {
-            res.set_content(R"({"message": "User updated successfully"})", "application/json");
-        } else {
-            res.status = 400;
-            res.set_content(R"({"error": "Failed to update user"})", "application/json");
-        } });
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
 
-    // DELETE /user/:id
-    server_->Delete(R"(/user/(\d+))", [this](const httplib::Request &req, httplib::Response &res)
-                    {
+        bool success = routHandler_->handleUpdateUser(userId, *jsonDataOpt);
+        if (success)
+        {
+            respondJson(res, json{{"message", "User updated successfully"}});
+        }
+        else
+        {
+            respondJson(res, json{{"error", "Failed to update user"}}, 400);
+        }
+    });
+
+    server_->Delete(R"(/user/(\d+))", [this, respondJson](const httplib::Request &req, httplib::Response &res)
+    {
         std::string userId = req.matches[1];
         logger_.logMeta(SingletonLogger::INFO, "DELETE /user/" + userId, __FILE__, __LINE__, __func__);
 
         bool deleted = routHandler_->handleDeleteUser(userId);
-        if (deleted) {
-            res.set_content(R"({"message": "User deleted successfully"})", "application/json");
-        } else {
-            res.status = 404;
-            res.set_content(R"({"error": "User not found"})", "application/json");
-        } });
-
-    // GET /users
-    server_->Get("/users", [this](const httplib::Request &req, httplib::Response &res)
-                 {
-        logger_.logMeta(SingletonLogger::INFO, "GET /users", __FILE__, __LINE__, __func__);
-
-        auto users = routHandler_->handleGetAllUsers();
-        res.set_content(users.dump(), "application/json"); });
-
-    // PATCH /user/:id/password
-    server_->Patch(R"(/user/(\d+)/password)", [this](const httplib::Request &req, httplib::Response &res)
-                   {
-    std::string userId = req.matches[1];
-    auto jsonData = Json::parse(req.body);
-
-    if (jsonData.contains("oldPassword") && jsonData.contains("newPassword")) {
-        std::string oldPassword = jsonData["oldPassword"];
-        std::string newPassword = jsonData["newPassword"];
-
-        bool updated = routHandler_->handlePasswordUpdate(userId, oldPassword, newPassword);
-        if (updated) {
-            res.set_content(R"({"message": "Password updated"})", "application/json");
-        } else {
-            res.status = 400;
-            res.set_content(R"({"error": "Incorrect old password"})", "application/json");
+        if (deleted)
+        {
+            respondJson(res, json{{"message", "User deleted successfully"}});
         }
-    } else {
-        res.status = 400;
-        res.set_content(R"({"error": "Missing password fields"})", "application/json");
-    } });
+        else
+        {
+            respondJson(res, json{{"error", "User not found"}}, 404);
+        }
+    });
 
-    // PATCH /user/:id/profile
-    server_->Patch(R"(/user/(\d+)/profile)", [this](const httplib::Request &req, httplib::Response &res)
-                   {
-    std::string userId = req.matches[1];
-    auto jsonData = Json::parse(req.body);
+    server_->Get("/users", [this, respondJson](const httplib::Request &, httplib::Response &res)
+    {
+        logger_.logMeta(SingletonLogger::INFO, "GET /users", __FILE__, __LINE__, __func__);
+        respondJson(res, routHandler_->handleGetAllUsers());
+    });
 
-    bool updated = routHandler_->handlePartialProfileUpdate(userId, jsonData);
-    if (updated) {
-        res.set_content(R"({"message": "Profile updated"})", "application/json");
-    } else {
-        res.status = 400;
-        res.set_content(R"({"error": "Failed to update profile"})", "application/json");
-    } });
+    server_->Get("/users/paginated", [this, respondJson, parsePaginationParam](const httplib::Request &req, httplib::Response &res)
+    {
+        int offset = std::max(parsePaginationParam(req, "offset", 0), 0);
+        int limit = std::clamp(parsePaginationParam(req, "limit", 25), 1, 100);
 
-    // GET /user/search?username=abc
-    server_->Get("/user/search", [this](const httplib::Request &req, httplib::Response &res)
-                 {
-    if (req.has_param("username")) {
+        json response;
+        response["data"] = routHandler_->handleGetUsersPaginated(offset, limit);
+        response["meta"] = {
+            {"offset", offset},
+            {"limit", limit}
+        };
+
+        respondJson(res, response);
+    });
+
+    server_->Get("/users/stats", [this, respondJson](const httplib::Request &, httplib::Response &res)
+    {
+        respondJson(res, routHandler_->getUserStats());
+    });
+
+    server_->Get("/user/exists", [this, respondJson](const httplib::Request &req, httplib::Response &res)
+    {
+        std::string username = req.has_param("username") ? req.get_param_value("username") : std::string{};
+        std::string email = req.has_param("email") ? req.get_param_value("email") : std::string{};
+
+        if (username.empty() && email.empty())
+        {
+            respondJson(res, json{{"error", "Provide username or email to check"}}, 400);
+            return;
+        }
+
+        respondJson(res, routHandler_->checkUserAvailability(username, email));
+    });
+
+    server_->Patch(R"(/user/(\d+)/password)", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
+    {
+        std::string userId = req.matches[1];
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+
+        const auto &jsonData = *jsonDataOpt;
+        if (!jsonData.contains("oldPassword") || !jsonData.contains("newPassword"))
+        {
+            respondJson(res, json{{"error", "Missing password fields"}}, 400);
+            return;
+        }
+
+        bool updated = routHandler_->handlePasswordUpdate(
+            userId,
+            jsonData.at("oldPassword").get<std::string>(),
+            jsonData.at("newPassword").get<std::string>());
+
+        if (updated)
+        {
+            respondJson(res, json{{"message", "Password updated"}});
+        }
+        else
+        {
+            respondJson(res, json{{"error", "Incorrect old password"}}, 400);
+        }
+    });
+
+    server_->Patch(R"(/user/(\d+)/profile)", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
+    {
+        std::string userId = req.matches[1];
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+
+        bool updated = routHandler_->handlePartialProfileUpdate(userId, *jsonDataOpt);
+        if (updated)
+        {
+            respondJson(res, json{{"message", "Profile updated"}});
+        }
+        else
+        {
+            respondJson(res, json{{"error", "Failed to update profile"}}, 400);
+        }
+    });
+
+    server_->Get("/user/search", [this, respondJson](const httplib::Request &req, httplib::Response &res)
+    {
+        if (!req.has_param("username"))
+        {
+            respondJson(res, json{{"error", "Missing search parameter"}}, 400);
+            return;
+        }
+
         std::string username = req.get_param_value("username");
-        auto result = routHandler_->searchUsersByUsername(username);
-        res.set_content(result.dump(), "application/json");
-    } else {
-        res.status = 400;
-        res.set_content(R"({"error": "Missing search parameter"})", "application/json");
-    } });
+        respondJson(res, routHandler_->searchUsersByUsername(username));
+    });
 
-    // GET /user/me (JWT required)
-    server_->Get("/user/me", [this](const httplib::Request &req, httplib::Response &res)
-                 {
-    if (req.has_header("Authorization")) {
-        std::string token = req.get_header_value("Authorization");
+    server_->Get("/user/me", [this, respondJson, sanitizeToken](const httplib::Request &req, httplib::Response &res)
+    {
+        if (!req.has_header("Authorization"))
+        {
+            respondJson(res, json{{"error", "Missing Authorization header"}}, 400);
+            return;
+        }
+
+        std::string token = sanitizeToken(req.get_header_value("Authorization"));
         std::string userId;
 
-        if (jwt_.verifyToken(token, userId)) {
+        if (jwt_.verifyToken(token, userId))
+        {
             auto userJson = routHandler_->handleGetUserById(userId);
-            res.set_content(userJson.dump(), "application/json");
-        } else {
-            res.status = 401;
-            res.set_content(R"({"error": "Invalid token"})", "application/json");
+            respondJson(res, userJson);
         }
-    } else {
-        res.status = 400;
-        res.set_content(R"({"error": "Missing Authorization header"})", "application/json");
-    } });
+        else
+        {
+            respondJson(res, json{{"error", "Invalid token"}}, 401);
+        }
+    });
 
-    // POST /user/logout
-    server_->Post("/user/logout", [this](const httplib::Request &req, httplib::Response &res)
-                  {
-    // If session-based, invalidate session; if JWT-based, just return success
-    res.set_content(R"({"message": "Logged out"})", "application/json"); });
+    server_->Post("/user/refresh-token", [this, respondJson, parseBody, sanitizeToken](const httplib::Request &req, httplib::Response &res)
+    {
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+
+        const auto &jsonData = *jsonDataOpt;
+        if (!jsonData.contains("token"))
+        {
+            respondJson(res, json{{"error", "Missing token field"}}, 400);
+            return;
+        }
+
+        std::string token = sanitizeToken(jsonData.at("token").get<std::string>());
+        std::string newToken = jwt_.refreshToken(token);
+
+        if (newToken.empty())
+        {
+            respondJson(res, json{{"error", "Invalid or expired token"}}, 401);
+            return;
+        }
+
+        auto subject = jwt_.extractSubject(newToken);
+        respondJson(res, json{{"token", newToken}, {"user_id", subject.value_or(std::string{})}});
+    });
+
+    server_->Post("/user/token/introspect", [this, respondJson, parseBody, sanitizeToken](const httplib::Request &req, httplib::Response &res)
+    {
+        auto jsonDataOpt = parseBody(req, res);
+        if (!jsonDataOpt)
+        {
+            return;
+        }
+
+        const auto &jsonData = *jsonDataOpt;
+        if (!jsonData.contains("token"))
+        {
+            respondJson(res, json{{"error", "Missing token field"}}, 400);
+            return;
+        }
+
+        std::string token = sanitizeToken(jsonData.at("token").get<std::string>());
+        std::string userId;
+
+        if (!jwt_.verifyToken(token, userId))
+        {
+            respondJson(res, json{{"valid", false}}, 401);
+            return;
+        }
+
+        respondJson(res, json{{"valid", true}, {"user_id", userId}});
+    });
+
+    server_->Get("/health", [this, respondJson](const httplib::Request &, httplib::Response &res)
+    {
+        respondJson(res, routHandler_->getHealthStatus());
+    });
+
+    server_->Post("/user/logout", [respondJson](const httplib::Request &, httplib::Response &res)
+    {
+        respondJson(res, json{{"message", "Logged out"}});
+    });
 }

--- a/UserManager/src/services/httpHandler/httpHandler.cpp
+++ b/UserManager/src/services/httpHandler/httpHandler.cpp
@@ -18,7 +18,11 @@ void HttpHandler::createServers()
 {
     logger_.logMeta(SingletonLogger::INFO, "Creating a lightweight HTTP server.", __FILE__, __LINE__, __func__);
     
-    auto httpUserHandler_ = std::make_unique<UberBackend::HttpUserServer>( "httpUserHandler","localhost", UberUtils::CONFIG::USER_MANAGER_HTTP_USER_HANDLER_PORT, database_);
+    auto httpUserHandler_ = std::make_unique<UberBackend::HttpUserServer>(
+        "httpUserHandler",
+        UberUtils::CONFIG::getUserManagerHost(),
+        static_cast<int>(UberUtils::CONFIG::getUserManagerHttpPort()),
+        database_);
     httpUserHandler_->createServerMethods();
 
     logger_.logMeta(SingletonLogger::INFO, "Added lightweight server to vector.", __FILE__, __LINE__, __func__);

--- a/sharedResources/src/sharedDatabase.cpp
+++ b/sharedResources/src/sharedDatabase.cpp
@@ -116,9 +116,14 @@ bool SharedDatabase::executeSelect(const std::string &query)
 std::string SharedDatabase::escapeString(const std::string &input)
 {
     logger_.logMeta(SingletonLogger::INFO, "Escaping: " + input, __FILE__, __LINE__, __func__);
-    if (input.empty() || input == "NULL" || input == "null" || input == "''" || input == "\"\"" || input == "")
+    if (input.empty())
     {
-        logger_.logMeta(SingletonLogger::ERROR, "Input string is empty.", __FILE__, __LINE__, __func__);
+        logger_.logMeta(SingletonLogger::DEBUG, "Empty string provided to escapeString; returning empty value.", __FILE__, __LINE__, __func__);
+        return "";
+    }
+    if (input == "NULL" || input == "null" || input == "''" || input == "\"\"")
+    {
+        logger_.logMeta(SingletonLogger::WARNING, "Received sentinel null-like value for escapeString; returning empty.", __FILE__, __LINE__, __func__);
         return "";
     }
     std::string result = database_->escapeString(input);

--- a/sharedUtils/include/jwt.h
+++ b/sharedUtils/include/jwt.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <optional>
 #include <string>
+
 #include <utils/index.h>
 #include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
@@ -11,6 +13,8 @@ namespace UberBackend {
 
         std::string generateToken(const std::string &userId, int expirySeconds = 3600);
         bool verifyToken(const std::string &token, std::string &userId);
+        std::optional<std::string> extractSubject(const std::string &token);
+        std::string refreshToken(const std::string &token, int expirySeconds = 3600);
 
     private:
         std::string secretKey_;

--- a/sharedUtils/src/config.cpp
+++ b/sharedUtils/src/config.cpp
@@ -1,0 +1,197 @@
+#include "../include/config.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using namespace UberBackend;
+
+namespace
+{
+    constexpr const char *DEFAULT_ENV_FILE = ".env";
+}
+
+ConfigManager &ConfigManager::instance()
+{
+    static ConfigManager instance;
+    return instance;
+}
+
+ConfigManager::ConfigManager()
+    : loaded_(false), envPath_(DEFAULT_ENV_FILE), logger_(utils::SingletonLogger::instance())
+{
+}
+
+void ConfigManager::loadFromFile(const std::string &envPath)
+{
+    std::unique_lock lock(mutex_);
+    if (!envPath.empty())
+    {
+        envPath_ = envPath;
+    }
+    loaded_ = false;
+    values_.clear();
+}
+
+void ConfigManager::reload()
+{
+    std::unique_lock lock(mutex_);
+    loaded_ = false;
+}
+
+std::string ConfigManager::getString(const std::string &key, const std::string &defaultValue) const
+{
+    ensureLoaded();
+
+    if (const char *envValue = std::getenv(key.c_str()); envValue != nullptr)
+    {
+        return std::string(envValue);
+    }
+
+    std::shared_lock lock(mutex_);
+    auto it = values_.find(key);
+    if (it != values_.end())
+    {
+        return it->second;
+    }
+
+    return defaultValue;
+}
+
+int ConfigManager::getInt(const std::string &key, int defaultValue) const
+{
+    const std::string value = getString(key, std::to_string(defaultValue));
+    try
+    {
+        return std::stoi(value);
+    }
+    catch (const std::exception &e)
+    {
+        logger_.logMeta(utils::SingletonLogger::WARNING,
+                        "ConfigManager::getInt fallback for key " + key + ": " + e.what(),
+                        __FILE__, __LINE__, __func__);
+        return defaultValue;
+    }
+}
+
+unsigned int ConfigManager::getUnsigned(const std::string &key, unsigned int defaultValue) const
+{
+    const int parsed = getInt(key, static_cast<int>(defaultValue));
+    return parsed < 0 ? defaultValue : static_cast<unsigned int>(parsed);
+}
+
+bool ConfigManager::getBool(const std::string &key, bool defaultValue) const
+{
+    const std::string value = getString(key, defaultValue ? "true" : "false");
+
+    if (value == "1" || value == "true" || value == "TRUE" || value == "True")
+    {
+        return true;
+    }
+    if (value == "0" || value == "false" || value == "FALSE" || value == "False")
+    {
+        return false;
+    }
+
+    return defaultValue;
+}
+
+double ConfigManager::getDouble(const std::string &key, double defaultValue) const
+{
+    const std::string value = getString(key, std::to_string(defaultValue));
+    try
+    {
+        return std::stod(value);
+    }
+    catch (const std::exception &e)
+    {
+        logger_.logMeta(utils::SingletonLogger::WARNING,
+                        "ConfigManager::getDouble fallback for key " + key + ": " + e.what(),
+                        __FILE__, __LINE__, __func__);
+        return defaultValue;
+    }
+}
+
+void ConfigManager::ensureLoaded() const
+{
+    if (loaded_)
+    {
+        return;
+    }
+
+    std::unique_lock lock(mutex_);
+    if (!loaded_)
+    {
+        const_cast<ConfigManager *>(this)->loadUnlocked();
+        loaded_ = true;
+    }
+}
+
+void ConfigManager::loadUnlocked()
+{
+    values_.clear();
+
+    if (envPath_.empty())
+    {
+        logger_.logMeta(utils::SingletonLogger::WARNING,
+                        "ConfigManager invoked without an env path; skipping file load.",
+                        __FILE__, __LINE__, __func__);
+        return;
+    }
+
+    std::ifstream file(envPath_);
+    if (!file.is_open())
+    {
+        logger_.logMeta(utils::SingletonLogger::WARNING,
+                        "Unable to open env file at " + envPath_.string(),
+                        __FILE__, __LINE__, __func__);
+        return;
+    }
+
+    logger_.logMeta(utils::SingletonLogger::INFO,
+                    "Loading configuration from " + envPath_.string(),
+                    __FILE__, __LINE__, __func__);
+
+    std::string line;
+    while (std::getline(file, line))
+    {
+        line = trim(line);
+        if (line.empty() || line[0] == '#')
+        {
+            continue;
+        }
+
+        const auto separator = line.find('=');
+        if (separator == std::string::npos)
+        {
+            continue;
+        }
+
+        std::string key = trim(line.substr(0, separator));
+        std::string value = trim(line.substr(separator + 1));
+
+        if (!key.empty())
+        {
+            if (!value.empty() && value.front() == '"' && value.back() == '"' && value.size() > 1)
+            {
+                value = value.substr(1, value.size() - 2);
+            }
+            values_[key] = value;
+        }
+    }
+}
+
+std::string ConfigManager::trim(const std::string &value)
+{
+    const auto start = value.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos)
+    {
+        return "";
+    }
+
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(start, end - start + 1);
+}
+


### PR DESCRIPTION
## Summary
- introduce a reusable ConfigManager that loads settings from .env files or environment variables and update the UserManager boot flow to use it
- expand the UserManager HTTP server with validation, pagination, stats, health and token utility endpoints backed by new database helpers
- fix MySQL column name mismatches and hardening of escaping logic while adding duplicate checks and safer Kafka initialisation for user flows

## Testing
- not run (environment lacks required services)


------
https://chatgpt.com/codex/tasks/task_e_68d626bf04e48333b79d26def017db52