### PR TITLE
Replace external dependencies with in-memory stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Add subdirectories (these must each have their own CMakeLists.txt)
+add_subdirectory(sharedUtils)
+add_subdirectory(sharedResources)
 add_subdirectory(UserManager)
 add_subdirectory(RideManager)
 add_subdirectory(LocationManager)

--- a/LocationManager/CMakeLists.txt
+++ b/LocationManager/CMakeLists.txt
@@ -6,70 +6,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# --- Define Dependencies ---
-set(DEPENDENCIES
-    app_utils::app_utils
-    app_kafka::app_kafka
-    app_rabbitmq::app_rabbitmq
-    app_h3::app_h3
-    h3::h3
-    app_database::app_database
-    app_algorithms::app_algorithms
-    gRPC::grpc++
-    gRPC::grpc
-    gRPC::grpc++_reflection
-    protobuf::libprotobuf
-    protobuf::libprotoc  # Optional: Only if you use protoc-related C++ APIs
-    absl::base
-    absl::synchronization
-    absl::strings
-    absl::time
-    absl::str_format
-    absl::status
-    absl::random_random
-    absl::hash
-    jwt-cpp::jwt-cpp
-    nlohmann_json::nlohmann_json
-    hiredis::hiredis
-    redis++::redis++
-)
-
-# --- Packages to Find ---
-set(PACKAGES
-    app_utils
-    app_kafka
-    app_rabbitmq
-    app_h3
-    h3
-    app_database
-    app_algorithms
-    protobuf
-    gRPC
-    absl
-    jwt-cpp
-    nlohmann_json
-    hiredis
-    redis++
-)
-
-# --- Find Packages ---
-foreach(pack ${PACKAGES})
-    find_package(${pack} CONFIG REQUIRED)
-endforeach()
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # --- Source Files ---
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
-file(GLOB_RECURSE SHARED_RESOURCES CONFIGURE_DEPENDS ../sharedResources/src/*.cpp)
-file(GLOB_RECURSE PROTO_SRCS CONFIGURE_DEPENDS ../proto/*.pb.cc ../proto/*.grpc.pb.cc)
-file(GLOB_RECURSE PROTO_HDRS CONFIGURE_DEPENDS ../proto/*.pb.h ../proto/*.grpc.pb.h)
-file(GLOB_RECURSE UTILS CONFIGURE_DEPENDS ../sharedUtils/src/*.cpp)
-
 # --- Executable ---
 add_executable(${PROJECT_NAME}
     ${SRC_FILES}
-    ${SHARED_RESOURCES}
-    ${PROTO_SRCS}
-    ${UTILS}
 )
 
 # --- Include Directories ---
@@ -77,11 +20,11 @@ target_include_directories(${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ../sharedResources/include
-        ../proto
         ../sharedUtils/include
 )
 
 # --- Link Dependencies ---
 target_link_libraries(${PROJECT_NAME}
-    PRIVATE ${DEPENDENCIES}
+    PRIVATE
+        uber_shared_resources
 )

--- a/LocationManager/include/services/h3Handler/h3Handler.h
+++ b/LocationManager/include/services/h3Handler/h3Handler.h
@@ -3,8 +3,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <h3/h3api.h>
-
 #include <utils/index.h>
 #include <h3/index.h>
 

--- a/LocationManager/include/services/redisHandler/redisHandler.h
+++ b/LocationManager/include/services/redisHandler/redisHandler.h
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <memory>
 #include <future>
-#include <sw/redis++/redis++.h>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <utils/index.h>
-
-using namespace sw::redis;
-using namespace utils;
 
 namespace UberBackend {
 
@@ -22,8 +24,10 @@ namespace UberBackend {
         std::vector<std::string> getDriversFromSet(const std::string& h3Index);
 
     private:
-        SingletonLogger &logger_;
-        std::shared_ptr<Redis> redis_;
+        utils::SingletonLogger &logger_;
+        mutable std::mutex mutex_;
+        std::unordered_map<std::string, std::string> keyValueStore_;
+        std::unordered_map<std::string, std::unordered_set<std::string>> setStore_;
     };
 
 }

--- a/LocationManager/src/main.cpp
+++ b/LocationManager/src/main.cpp
@@ -6,7 +6,7 @@
 using namespace utils;
 using namespace UberBackend;
 
-auto &logger_ = SingletonLogger::instance("log/LocationServerLog.txt");
+auto &logger_ = SingletonLogger::instance();
 
 std::unique_ptr<Server> server_ = std::make_unique<Server>("LocationManager",
                                                            UberUtils::CONFIG::LOCATION_MANAGER_HOST,

--- a/LocationManager/src/server.cpp
+++ b/LocationManager/src/server.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
+#include "../../sharedResources/include/sharedRabbitMQConsumer.h"
 
 
 using namespace utils;

--- a/LocationManager/src/services/redisHandler/redisHandler.cpp
+++ b/LocationManager/src/services/redisHandler/redisHandler.cpp
@@ -1,73 +1,53 @@
 #include "../../../include/services/redisHandler/redisHandler.h"
-#include <sw/redis++/redis++.h>
-#include <optional>
 
-using namespace UberBackend;
-using namespace sw::redis;
-
-RedisHandler::RedisHandler() : logger_(SingletonLogger::instance())
+namespace UberBackend
 {
-    try
-    {
-        redis_ = std::make_shared<Redis>("tcp://127.0.0.1:6379");
-        logger_.logMeta(SingletonLogger::INFO, "Connected to Redis", __FILE__, __LINE__, __func__);
-    }
-    catch (const sw::redis::Error &e)
-    {
-        logger_.logMeta(SingletonLogger::ERROR, "Failed to connect to Redis: " + std::string(e.what()), __FILE__, __LINE__, __func__);
-    }
+
+RedisHandler::RedisHandler()
+    : logger_(utils::SingletonLogger::instance())
+{
+    logger_.logMeta(utils::SingletonLogger::INFO,
+                    "Initialised in-memory Redis handler",
+                    __FILE__,
+                    __LINE__,
+                    __func__);
 }
 
 RedisHandler::~RedisHandler() = default;
 
 void RedisHandler::setValue(const std::string &key, const std::string &value)
 {
-    try
-    {
-        redis_->set(key, value);
-    }
-    catch (const sw::redis::Error &e)
-    {
-        logger_.logMeta(SingletonLogger::ERROR, "Redis SET failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
-    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    keyValueStore_[key] = value;
 }
 
 std::optional<std::string> RedisHandler::getValue(const std::string &key)
 {
-    try
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (auto it = keyValueStore_.find(key); it != keyValueStore_.end())
     {
-        return redis_->get(key);
+        return it->second;
     }
-    catch (const sw::redis::Error &e)
-    {
-        logger_.logMeta(SingletonLogger::ERROR, "Redis GET failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
-        return std::nullopt;
-    }
+    return std::nullopt;
 }
 
 void RedisHandler::addDriverToSet(const std::string &h3Index, const std::string &driverId)
 {
-    try
-    {
-        redis_->sadd("available_drivers:" + h3Index, driverId);
-    }
-    catch (const sw::redis::Error &e)
-    {
-        logger_.logMeta(SingletonLogger::ERROR, "Redis SADD failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
-    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    setStore_["available_drivers:" + h3Index].insert(driverId);
 }
 
 std::vector<std::string> RedisHandler::getDriversFromSet(const std::string &h3Index)
 {
-    try
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto key = "available_drivers:" + h3Index;
+    auto it = setStore_.find(key);
+    if (it == setStore_.end())
     {
-        std::vector<std::string> result;
-        redis_->smembers("available_drivers:" + h3Index, std::back_inserter(result));
-        return result;
-    }
-    catch (const sw::redis::Error &e)
-    {
-        logger_.logMeta(SingletonLogger::ERROR, "Redis SMEMBERS failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
         return {};
     }
+
+    return std::vector<std::string>(it->second.begin(), it->second.end());
 }
+
+} // namespace UberBackend

--- a/RideManager/CMakeLists.txt
+++ b/RideManager/CMakeLists.txt
@@ -6,28 +6,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(RideManager)
 
-# Dependencies this target needs
-set(DEPENDENCIES
-    app_utils::app_utils
-    app_kafka::app_kafka
-    app_h3::app_h3
-    h3::h3
-    app_database::app_database
-)
-
-# Packages we need to find
-set(PACKAGES
-    app_utils
-    app_kafka
-    app_h3
-    h3
-    app_database
-)
-
-# Find required packages
-foreach(pack ${PACKAGES})
-    find_package(${pack} CONFIG REQUIRED)
-endforeach()
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # Collect source files
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
@@ -36,4 +15,7 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
 add_executable(${PROJECT_NAME} ${SRC_FILES})
 
 # Link dependencies
-target_link_libraries(${PROJECT_NAME} PRIVATE ${DEPENDENCIES})
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        uber_shared_resources
+)

--- a/RideManager/src/main.cpp
+++ b/RideManager/src/main.cpp
@@ -1,14 +1,24 @@
 #include <iostream>
-#include <memory>
 
-#include <database/index.h>
-
-#include "database/database.h"
 #include <utils/index.h>
-using namespace utils;
 
 int main()
 {
-    auto fileLogger = std::make_unique<FileLogger>("log/RideManagerLog.txt"); // ✅ properly initialized
-    fileLogger->logMeta(FileLogger::ERROR, "Create database instance.", __FILE__, __LINE__, __func__);
-};
+    auto &logger = utils::SingletonLogger::instance();
+    logger.logMeta(utils::SingletonLogger::INFO,
+                   "Starting Ride Manager stub server (in-memory mode)",
+                   __FILE__,
+                   __LINE__,
+                   __func__);
+
+    std::cout << "RideManager service initialised with stubbed dependencies." << std::endl;
+    std::cout << "Press Enter to exit..." << std::endl;
+    std::cin.get();
+
+    logger.logMeta(utils::SingletonLogger::INFO,
+                   "Shutting down Ride Manager stub server",
+                   __FILE__,
+                   __LINE__,
+                   __func__);
+    return 0;
+}

--- a/UserManager/CMakeLists.txt
+++ b/UserManager/CMakeLists.txt
@@ -6,66 +6,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# --- Define Dependencies ---
-set(DEPENDENCIES
-    app_utils::app_utils
-    app_kafka::app_kafka
-    app_rabbitmq::app_rabbitmq
-    app_h3::app_h3
-    h3::h3
-    app_database::app_database
-    app_algorithms::app_algorithms
-    gRPC::grpc++
-    gRPC::grpc
-    gRPC::grpc++_reflection
-    protobuf::libprotobuf
-    protobuf::libprotoc  # Optional: Only if you use protoc-related C++ APIs
-    absl::base
-    absl::synchronization
-    absl::strings
-    absl::time
-    absl::str_format
-    absl::status
-    absl::random_random
-    absl::hash
-    jwt-cpp::jwt-cpp
-    nlohmann_json::nlohmann_json
-)
-
-# --- Packages to Find ---
-set(PACKAGES
-    app_utils
-    app_kafka
-    app_rabbitmq
-    app_h3
-    h3
-    app_database
-    app_algorithms
-    protobuf
-    gRPC
-    absl
-    jwt-cpp
-    nlohmann_json
-)
-
-# --- Find Packages ---
-foreach(pack ${PACKAGES})
-    find_package(${pack} CONFIG REQUIRED)
-endforeach()
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # --- Source Files ---
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)
-file(GLOB_RECURSE SHARED_RESOURCES CONFIGURE_DEPENDS ../sharedResources/src/*.cpp)
-file(GLOB_RECURSE PROTO_SRCS CONFIGURE_DEPENDS ../proto/*.pb.cc ../proto/*.grpc.pb.cc)
-file(GLOB_RECURSE PROTO_HDRS CONFIGURE_DEPENDS ../proto/*.pb.h ../proto/*.grpc.pb.h)
-file(GLOB_RECURSE UTILS CONFIGURE_DEPENDS ../sharedUtils/src/*.cpp)
-
 # --- Executable ---
 add_executable(${PROJECT_NAME}
     ${SRC_FILES}
-    ${SHARED_RESOURCES}
-    ${PROTO_SRCS}
-    ${UTILS}
 )
 
 # --- Include Directories ---
@@ -73,11 +20,11 @@ target_include_directories(${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ../sharedResources/include
-        ../proto
         ../sharedUtils/include
 )
 
 # --- Link Dependencies ---
 target_link_libraries(${PROJECT_NAME}
-    PRIVATE ${DEPENDENCIES}
+    PRIVATE
+        uber_shared_resources
 )

--- a/UserManager/include/services/kafkaHandler/producer/userKafkaManager.h
+++ b/UserManager/include/services/kafkaHandler/producer/userKafkaManager.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include <nlohmann/json.hpp>
+
 #include <utils/index.h>
 #include "../../../models/user.h"
 #include "../../../../../sharedResources/include/sharedKafkaProducer.h"

--- a/UserManager/src/main.cpp
+++ b/UserManager/src/main.cpp
@@ -8,7 +8,7 @@ using namespace utils;
 using namespace UberBackend;
 
 // Getting instance of the Singleton logger
-auto &logger_ = SingletonLogger::instance("log/UserServerLog.txt");
+auto &logger_ = SingletonLogger::instance();
 
 // Creating a unique pointer for the Server instance
 std::unique_ptr<Server> server_;

--- a/UserManager/src/server.cpp
+++ b/UserManager/src/server.cpp
@@ -2,6 +2,7 @@
 
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
+#include "../../sharedResources/include/sharedRabbitMQConsumer.h"
 
 using namespace utils;
 using namespace UberBackend;

--- a/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
+++ b/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
@@ -4,8 +4,8 @@
 
 #include <nlohmann/json.hpp>
 
-#include "../include/services/httpHandler/servers/httpUserServer.h"
-#include "../../../../sharedUtils/include/config.h"
+#include "../../../../include/services/httpHandler/servers/httpUserServer.h"
+#include "../../../../../sharedUtils/include/config.h"
 
 using namespace UberBackend;
 using namespace utils;

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,20 +9,7 @@ class BaseRecipe(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain"
 
     def requirements(self):
-        self.requires("protobuf/3.21.12", transitive_headers=True, transitive_libs=True)
-        self.requires("grpc/1.54.3")
-        self.requires("abseil/20230125.3")
-        self.requires("jwt-cpp/0.7.0")
         self.requires("nlohmann_json/3.11.2")
-        self.requires("hiredis/1.0.0")
-    
-        self.requires("app_utils/1.0@pasan/testing")
-        self.requires("app_kafka/1.0@pasan/testing")
-        self.requires("app_rabbitmq/1.0@pasan/testing")
-        self.requires("app_h3/1.0@pasan/testing")
-        self.requires("app_blockchain/1.0@pasan/testing")
-        self.requires("app_algorithms/1.0@pasan/testing")
-        self.requires("app_database/1.0@pasan/testing")
 
     def layout(self):
         cmake_layout(self)

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -2,167 +2,32 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# --- Install base tools and dependencies ---
+# --- Core build toolchain ---
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     curl \
     wget \
-    cmake \
-    pkg-config \
-    lsb-release \
-    software-properties-common \
     python3 \
     python3-pip \
-    unzip \
-    uuid-dev \
-    libsasl2-dev \
-    libssl-dev \
-    libpq-dev \
-    libmysqlclient-dev \
-    libsqlite3-dev \
-    librabbitmq-dev \
-    librdkafka-dev \
-    libcurl4-openssl-dev \
-    autoconf \
-    libtool \
-    protobuf-compiler \
-    libc-ares-dev \
-    pigz \
-    zlib1g \
+    ninja-build \
+    pkg-config \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Upgrade to latest CMake (>= 3.25) ---
-RUN apt-get purge --auto-remove -y cmake && \
-    curl -LO https://github.com/Kitware/CMake/releases/download/v3.27.9/cmake-3.27.9-linux-x86_64.sh && \
+# --- Install modern CMake ---
+RUN curl -LO https://github.com/Kitware/CMake/releases/download/v3.27.9/cmake-3.27.9-linux-x86_64.sh && \
     chmod +x cmake-3.27.9-linux-x86_64.sh && \
     ./cmake-3.27.9-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     rm cmake-3.27.9-linux-x86_64.sh
 
-# --- Build and install Uber H3 ---
-RUN git clone https://github.com/uber/h3.git /tmp/h3 && \
-    cd /tmp/h3 && mkdir build && cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
-    make -j$(nproc) && make install && cd / && rm -rf /tmp/h3
-
-# --- Build librdkafka ---
-RUN git clone https://github.com/confluentinc/librdkafka.git /tmp/librdkafka && \
-    cd /tmp/librdkafka && mkdir build && cd build && \
-    cmake .. && make -j$(nproc) && make install && cd / && rm -rf /tmp/librdkafka
-
-# --- Build rabbitmq-c ---
-RUN git clone https://github.com/alanxz/rabbitmq-c.git /tmp/rabbitmq-c && \
-    cd /tmp/rabbitmq-c && mkdir build && cd build && \
-    cmake .. -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=ON -DENABLE_SSL_SUPPORT=ON -DBUILD_TESTS=OFF && \
-    make -j$(nproc) && make install && cd / && rm -rf /tmp/rabbitmq-c
-
-# --- Install nlohmann_json (header-only) ---
-RUN git clone https://github.com/nlohmann/json.git /tmp/json && \
-    cd /tmp/json && mkdir build && cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && make install && cd / && rm -rf /tmp/json
-
-# --- Install httplib (single header) ---
-RUN curl -Lo /usr/local/include/httplib.h https://raw.githubusercontent.com/yhirose/cpp-httplib/master/httplib.h
-
-# Clone and build AMQP-CPP
-RUN git clone https://github.com/akalend/amqpcpp.git && git clone https://github.com/alanxz/rabbitmq-c.git /amqpcpp/rabbitmq-c && \
-    cd amqpcpp && mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DAMQP-CPP_BUILD_SHARED=ON && \
-    make -j$(nproc) && make install && cp libamqpcpp.so /usr/local/lib && cp -r ../include/* /usr/local/include && \
-    cd ../.. 
-
-RUN git clone https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git && \
-    cd AMQP-CPP && mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DAMQP-CPP_BUILD_SHARED=ON && \
-    make -j$(nproc) && make install && \
-    cd ../.. 
-
-RUN cp /amqpcpp/build/libamqpcpp.so /usr/local/lib
-
-# --- Fix include path for rabbitmq-c / AMQP ---
-RUN mkdir -p /usr/local/include/rabbitmq-c && \
-    ln -sf /usr/local/include/AMQPcpp.h /usr/local/include/rabbitmq-c/AMQPcpp.h
-
-# Clone and build gRPC with all submodules
-WORKDIR /tmp
-
-RUN git clone --recurse-submodules -b v1.63.0 https://github.com/grpc/grpc && \
-    cd grpc && mkdir -p cmake/build && cd cmake/build && \
-    cmake ../.. \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DgRPC_INSTALL=ON \
-        -DgRPC_BUILD_TESTS=OFF \
-        -DgRPC_PROTOBUF_PROVIDER=module \
-        -DgRPC_ZLIB_PROVIDER=package \
-        -DgRPC_CARES_PROVIDER=module \
-        -DgRPC_ABSL_PROVIDER=module \
-        -DgRPC_RE2_PROVIDER=module && \
-    make -j$(nproc) && make install && \
-    cd / && rm -rf /tmp/grpc
-
-# Download, build, and install zlib 1.3.1
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    wget \
-    git \
-    && cd /tmp \
-    && wget http://zlib.net/zlib-1.3.1.tar.gz \
-    && tar -xvzf zlib-1.3.1.tar.gz \
-    && cd zlib-1.3.1 \
-    && ./configure \
-    && make \
-    && make install \
-    && echo "/usr/local/lib" > /etc/ld.so.conf.d/zlib.conf \
-    && ldconfig \
-    && cd /tmp \
-    && rm -rf zlib-1.3.1*
-
-# Optionally rebuild pigz to use new zlib
-RUN git clone https://github.com/madler/pigz.git /tmp/pigz \
-    && cd /tmp/pigz \
-    && make \
-    && cp pigz unpigz /usr/local/bin \
-    && rm -rf /tmp/pigz
-
-# --- Build hiredis ---
-RUN git clone https://github.com/redis/hiredis.git /tmp/hiredis && \
-    cd /tmp/hiredis && \
-    make -j$(nproc) && make install && \
-    ldconfig && \
-    rm -rf /tmp/hiredis
-
-# --- Build redis-plus-plus ---
-RUN git clone https://github.com/sewenew/redis-plus-plus.git /tmp/redis-plus-plus && \
-    cd /tmp/redis-plus-plus && mkdir -p build && cd build && \
-    cmake .. -DREDIS_PLUS_PLUS_BUILD_SHARED=ON -DREDIS_PLUS_PLUS_BUILD_STATIC=ON -DCMAKE_BUILD_TYPE=Release && \
-    make -j$(nproc) && make install && \
-    ldconfig && \
-    rm -rf /tmp/redis-plus-plus
-
-
-# --- Setup environment variables ---
-ENV CMAKE_PREFIX_PATH=/usr/local:/usr/local/lib/cmake:/usr/local/lib64/cmake:/usr/local/lib/cmake/RdKafka
-ENV CMAKE_MODULE_PATH=/usr/local/lib/cmake
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu
-ENV CPLUS_INCLUDE_PATH=/usr/local/include:/usr/local/include/rabbitmq-c
-
-# Ensure the system finds installed libraries
-RUN ldconfig
-
-# --- Install Conan ---
-RUN pip3 install conan && \
+# --- Conan package manager ---
+RUN pip3 install --no-cache-dir conan && \
     conan profile detect --force
 
-# --- Clone required C++ modules ---
-RUN git clone https://github.com/prrathnayake/cpp-base.git /opt/cpp-base && \
-    git clone https://github.com/prrathnayake/cpp-tools.git /opt/cpp-tools
+# --- Header-only utilities used by the services ---
+RUN curl -Lo /usr/local/include/httplib.h https://raw.githubusercontent.com/yhirose/cpp-httplib/master/httplib.h
 
-# --- Build and export cpp-tools ---
-RUN conan build /opt/cpp-tools --build=missing && \
-    conan export /opt/cpp-tools --user=pasan --channel=testing
-
-# --- Build cpp-base ---
-RUN python3 /opt/cpp-tools/module/scripts/buildBase.py /opt/cpp-base
+WORKDIR /app
 
 CMD ["/bin/bash"]

--- a/sharedResources/CMakeLists.txt
+++ b/sharedResources/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.25.2)
+
+find_package(nlohmann_json CONFIG REQUIRED)
+
+add_library(uber_shared_resources
+    src/sharedDatabase.cpp
+    src/sharedHTTPClient.cpp
+    src/sharedHTTPHandler.cpp
+    src/sharedHTTPServer.cpp
+    src/sharedKafkaConsumer.cpp
+    src/sharedKafkaHandler.cpp
+    src/sharedKafkaProducer.cpp
+    src/sharedRabbitMQConsumer.cpp
+    src/sharedRabbitMQHandler.cpp
+    src/sharedRabbitMQProducer.cpp
+    src/sharedRouteHandler.cpp
+    src/sharedServer.cpp
+    src/sharedgRPCClienth.cpp
+    src/sharedgRPCServer.cpp
+    src/database/MySQLDatabase.cpp
+    src/kafka/KafkaStub.cpp
+    src/h3/H3Stub.cpp
+)
+
+target_include_directories(uber_shared_resources
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/database
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/kafka
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/h3
+        ${CMAKE_CURRENT_SOURCE_DIR}/../sharedUtils/include
+)
+
+target_link_libraries(uber_shared_resources
+    PUBLIC
+        uber_shared_utils
+        nlohmann_json::nlohmann_json
+)
+
+add_library(app_utils INTERFACE)
+target_link_libraries(app_utils INTERFACE uber_shared_utils)
+add_library(app_utils::app_utils ALIAS app_utils)
+
+foreach(component IN ITEMS database kafka rabbitmq h3 blockchain algorithms)
+    add_library(app_${component} INTERFACE)
+    target_link_libraries(app_${component} INTERFACE uber_shared_resources)
+    add_library(app_${component}::app_${component} ALIAS app_${component})
+endforeach()
+
+if(NOT TARGET h3::h3)
+    add_library(h3_stub INTERFACE)
+    target_link_libraries(h3_stub INTERFACE uber_shared_resources)
+    target_include_directories(h3_stub INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/h3)
+    add_library(h3::h3 ALIAS h3_stub)
+endif()
+

--- a/sharedResources/include/database/MySQLDatabase.h
+++ b/sharedResources/include/database/MySQLDatabase.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <utils/index.h>
+
+namespace database {
+
+class MySQLDatabase {
+public:
+    MySQLDatabase(std::string host,
+                  std::string user,
+                  std::string password,
+                  unsigned int port,
+                  std::string databaseName);
+
+    bool runSqlScript(const std::string &path);
+    bool executeInsert(const std::string &query);
+    bool executeUpdate(const std::string &query);
+    bool executeDelete(const std::string &query);
+    bool executeSelect(const std::string &query);
+    std::string escapeString(const std::string &input) const;
+    std::vector<std::map<std::string, std::string>> fetchRows(const std::string &query) const;
+
+private:
+    std::string host_;
+    std::string user_;
+    std::string password_;
+    unsigned int port_;
+    std::string databaseName_;
+
+    mutable std::mutex mutex_;
+    utils::SingletonLogger &logger_;
+};
+
+} // namespace database
+

--- a/sharedResources/include/database/index.h
+++ b/sharedResources/include/database/index.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "MySQLDatabase.h"
+

--- a/sharedResources/include/h3/index.h
+++ b/sharedResources/include/h3/index.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace h3 {
+
+using H3Index = std::uint64_t;
+
+class H3 {
+public:
+    H3() = default;
+
+    H3Index getH3Index(double lat, double lon, int resolution) const;
+    std::string toString(H3Index index) const;
+    H3Index fromString(const std::string &value) const;
+    bool isValid(H3Index index) const;
+    std::vector<H3Index> getNeighbors(H3Index origin, int kRing) const;
+};
+
+} // namespace h3
+

--- a/sharedResources/include/kafka/index.h
+++ b/sharedResources/include/kafka/index.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <utils/index.h>
+
+namespace kafka {
+
+class KafkaBroker;
+
+class KafkaProducer {
+public:
+    explicit KafkaProducer(std::string bootstrapServers);
+    void produceMessages(const std::string &topic, const std::string &message);
+
+private:
+    std::string bootstrapServers_;
+    utils::SingletonLogger &logger_;
+};
+
+class KafkaConsumer {
+public:
+    KafkaConsumer(std::string bootstrapServers, std::string topic);
+    ~KafkaConsumer();
+
+    std::string consumeMessage();
+    void stopConsumeMessages();
+
+private:
+    std::string bootstrapServers_;
+    std::string topic_;
+    bool stopRequested_{false};
+    utils::SingletonLogger &logger_;
+};
+
+} // namespace kafka
+

--- a/sharedResources/include/sharedgRPCClient.h
+++ b/sharedResources/include/sharedgRPCClient.h
@@ -1,15 +1,8 @@
 #pragma once
 
-#include <memory>
 #include <string>
-#include <grpcpp/grpcpp.h>
-
-#include "../../proto/location.grpc.pb.h"
-#include "../../proto/location.pb.h"
 
 #include <utils/index.h>
-
-using namespace utils;
 
 namespace UberBackend
 {
@@ -17,13 +10,13 @@ namespace UberBackend
     class LocationClient
     {
     public:
-        explicit LocationClient(const std::shared_ptr<grpc::Channel> &channel);
+        explicit LocationClient(const std::string &endpoint = "localhost:50051");
 
         std::string SendLocation(const std::string &userID, double lat, double lon);
 
     private:
-        SingletonLogger &logger_;
-        std::unique_ptr<UberBackend::LocationService::Stub> stub_;  // ✅ Correct type
+        utils::SingletonLogger &logger_;
+        std::string endpoint_;
     };
 
 }

--- a/sharedResources/include/sharedgRPCServer.h
+++ b/sharedResources/include/sharedgRPCServer.h
@@ -1,15 +1,10 @@
 #pragma once
 
 #include <atomic>
-#include <memory>
 #include <mutex>
 #include <string>
 
-#include <grpcpp/grpcpp.h>
 #include <utils/index.h>
-
-#include "../../proto/location.grpc.pb.h"
-#include "../../proto/location.pb.h"
 
 namespace UberBackend
 {
@@ -25,8 +20,7 @@ namespace UberBackend
 
     protected:
         utils::SingletonLogger &logger_;
-        std::string serverAddress;
-        std::unique_ptr<grpc::Server> grpcServer;
+        std::string serverAddress_;
         mutable std::mutex mutex_;
         std::atomic<bool> running_{false};
     };

--- a/sharedResources/src/database/MySQLDatabase.cpp
+++ b/sharedResources/src/database/MySQLDatabase.cpp
@@ -1,0 +1,85 @@
+#include "../../include/database/MySQLDatabase.h"
+
+#include <fstream>
+
+namespace database {
+
+MySQLDatabase::MySQLDatabase(std::string host,
+                             std::string user,
+                             std::string password,
+                             unsigned int port,
+                             std::string databaseName)
+    : host_(std::move(host)),
+      user_(std::move(user)),
+      password_(std::move(password)),
+      port_(port),
+      databaseName_(std::move(databaseName)),
+      logger_(utils::SingletonLogger::instance())
+{
+    logger_.logMeta(utils::SingletonLogger::INFO,
+                    "Initialised stub MySQLDatabase for host=" + host_ + ":" + std::to_string(port_) +
+                        " db=" + databaseName_,
+                    __FILE__,
+                    __LINE__,
+                    __func__);
+}
+
+bool MySQLDatabase::runSqlScript(const std::string &path)
+{
+    std::ifstream script(path);
+    const bool ok = script.good();
+    logger_.logMeta(ok ? utils::SingletonLogger::INFO : utils::SingletonLogger::WARNING,
+                    ok ? "Processed SQL script at " + path : "Failed to open SQL script at " + path,
+                    __FILE__,
+                    __LINE__,
+                    __func__);
+    return ok;
+}
+
+bool MySQLDatabase::executeInsert(const std::string &query)
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG, "Stub INSERT query: " + query, __FILE__, __LINE__, __func__);
+    return !query.empty();
+}
+
+bool MySQLDatabase::executeUpdate(const std::string &query)
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG, "Stub UPDATE query: " + query, __FILE__, __LINE__, __func__);
+    return !query.empty();
+}
+
+bool MySQLDatabase::executeDelete(const std::string &query)
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG, "Stub DELETE query: " + query, __FILE__, __LINE__, __func__);
+    return !query.empty();
+}
+
+bool MySQLDatabase::executeSelect(const std::string &query)
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG, "Stub SELECT query: " + query, __FILE__, __LINE__, __func__);
+    return !query.empty();
+}
+
+std::string MySQLDatabase::escapeString(const std::string &input) const
+{
+    std::string escaped;
+    escaped.reserve(input.size());
+    for (char ch : input)
+    {
+        if (ch == '\\' || ch == '\'' || ch == '\"')
+        {
+            escaped.push_back('\\');
+        }
+        escaped.push_back(ch);
+    }
+    return escaped;
+}
+
+std::vector<std::map<std::string, std::string>> MySQLDatabase::fetchRows(const std::string &query) const
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG, "Stub fetch rows for query: " + query, __FILE__, __LINE__, __func__);
+    return {};
+}
+
+} // namespace database
+

--- a/sharedResources/src/h3/H3Stub.cpp
+++ b/sharedResources/src/h3/H3Stub.cpp
@@ -1,0 +1,50 @@
+#include "../../include/h3/index.h"
+
+#include <cmath>
+
+namespace h3 {
+
+H3Index H3::getH3Index(double lat, double lon, int resolution) const
+{
+    const std::uint64_t latBits = static_cast<std::uint64_t>((lat + 90.0) * 1000000.0);
+    const std::uint64_t lonBits = static_cast<std::uint64_t>((lon + 180.0) * 1000000.0);
+    const std::uint64_t resBits = static_cast<std::uint64_t>(resolution & 0xF);
+    return (latBits << 24) ^ (lonBits << 8) ^ resBits;
+}
+
+std::string H3::toString(H3Index index) const
+{
+    return std::to_string(index);
+}
+
+H3Index H3::fromString(const std::string &value) const
+{
+    try
+    {
+        return static_cast<H3Index>(std::stoull(value));
+    }
+    catch (...)
+    {
+        return 0;
+    }
+}
+
+bool H3::isValid(H3Index index) const
+{
+    return index != 0;
+}
+
+std::vector<H3Index> H3::getNeighbors(H3Index origin, int kRing) const
+{
+    std::vector<H3Index> neighbors;
+    const int count = std::max(0, kRing);
+    neighbors.reserve(static_cast<std::size_t>(count));
+    for (int i = 1; i <= count; ++i)
+    {
+        neighbors.push_back(origin + static_cast<H3Index>(i));
+    }
+    return neighbors;
+}
+
+} // namespace h3
+

--- a/sharedResources/src/kafka/KafkaStub.cpp
+++ b/sharedResources/src/kafka/KafkaStub.cpp
@@ -1,0 +1,136 @@
+#include "../../include/kafka/index.h"
+
+#include <map>
+#include <chrono>
+
+namespace kafka {
+namespace {
+struct TopicState {
+    std::deque<std::string> messages;
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool closed{false};
+};
+
+class InMemoryBroker {
+public:
+    static InMemoryBroker &instance()
+    {
+        static InMemoryBroker broker;
+        return broker;
+    }
+
+    void publish(const std::string &topic, const std::string &message)
+    {
+        auto state = getOrCreate(topic);
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->messages.push_back(message);
+        }
+        state->cv.notify_one();
+    }
+
+    std::string consume(const std::string &topic, bool stopRequested)
+    {
+        auto state = getOrCreate(topic);
+        std::unique_lock<std::mutex> lock(state->mutex);
+        state->cv.wait_for(lock, std::chrono::milliseconds(50), [&]() {
+            return !state->messages.empty() || state->closed || stopRequested;
+        });
+
+        if (!state->messages.empty())
+        {
+            std::string value = std::move(state->messages.front());
+            state->messages.pop_front();
+            return value;
+        }
+
+        return {};
+    }
+
+    void close(const std::string &topic)
+    {
+        auto state = getOrCreate(topic);
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->closed = true;
+        }
+        state->cv.notify_all();
+    }
+
+private:
+    std::shared_ptr<TopicState> getOrCreate(const std::string &topic)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = topics_.find(topic);
+        if (it != topics_.end())
+        {
+            if (auto state = it->second.lock())
+            {
+                return state;
+            }
+        }
+        auto state = std::make_shared<TopicState>();
+        topics_[topic] = state;
+        return state;
+    }
+
+    std::mutex mutex_;
+    std::map<std::string, std::weak_ptr<TopicState>> topics_;
+};
+} // namespace
+
+KafkaProducer::KafkaProducer(std::string bootstrapServers)
+    : bootstrapServers_(std::move(bootstrapServers)),
+      logger_(utils::SingletonLogger::instance())
+{
+    logger_.logMeta(utils::SingletonLogger::INFO,
+                    "KafkaProducer connected to " + bootstrapServers_,
+                    __FILE__,
+                    __LINE__,
+                    __func__);
+}
+
+void KafkaProducer::produceMessages(const std::string &topic, const std::string &message)
+{
+    logger_.logMeta(utils::SingletonLogger::DEBUG,
+                    "Producing message to topic " + topic + ": " + message,
+                    __FILE__,
+                    __LINE__,
+                    __func__);
+    InMemoryBroker::instance().publish(topic, message);
+}
+
+KafkaConsumer::KafkaConsumer(std::string bootstrapServers, std::string topic)
+    : bootstrapServers_(std::move(bootstrapServers)),
+      topic_(std::move(topic)),
+      logger_(utils::SingletonLogger::instance())
+{
+    logger_.logMeta(utils::SingletonLogger::INFO,
+                    "KafkaConsumer subscribed to " + topic_ + " via " + bootstrapServers_,
+                    __FILE__,
+                    __LINE__,
+                    __func__);
+}
+
+KafkaConsumer::~KafkaConsumer()
+{
+    stopConsumeMessages();
+}
+
+std::string KafkaConsumer::consumeMessage()
+{
+    return InMemoryBroker::instance().consume(topic_, stopRequested_);
+}
+
+void KafkaConsumer::stopConsumeMessages()
+{
+    if (!stopRequested_)
+    {
+        stopRequested_ = true;
+        InMemoryBroker::instance().close(topic_);
+    }
+}
+
+} // namespace kafka
+

--- a/sharedResources/src/sharedgRPCClienth.cpp
+++ b/sharedResources/src/sharedgRPCClienth.cpp
@@ -1,37 +1,30 @@
 #include "../include/sharedgRPCClient.h"
-#include <grpcpp/create_channel.h>
-#include <chrono>
 
 namespace UberBackend
 {
 
-    LocationClient::LocationClient(const std::shared_ptr<grpc::Channel> &channel)
-        : stub_(UberBackend::LocationService::NewStub(channel)),
-          logger_(utils::SingletonLogger::instance()) {}
+    LocationClient::LocationClient(const std::string &endpoint)
+        : logger_(utils::SingletonLogger::instance()),
+          endpoint_(endpoint)
+    {
+        logger_.logMeta(utils::SingletonLogger::INFO,
+                        "Initialized simulated gRPC client for " + endpoint_,
+                        __FILE__,
+                        __LINE__,
+                        __func__);
+    }
 
     std::string LocationClient::SendLocation(const std::string &userID, double lat, double lon)
     {
-        UberBackend::UserLocation request;
-        request.set_user_id(userID);
-        request.set_latitude(lat);
-        request.set_longitude(lon);
-        request.set_timestamp(std::chrono::system_clock::now().time_since_epoch().count());
-
-        UberBackend::LocationAck response;
-        grpc::ClientContext context;
-
-        grpc::Status status = stub_->SendLocation(&context, request, &response);
-
-        if (status.ok())
-        {
-            logger_.logMeta(utils::SingletonLogger::INFO, "Location sent successfully: " + response.message(), __FILE__, __LINE__, __func__);
-            return response.message();
-        }
-        else
-        {
-            logger_.logMeta(utils::SingletonLogger::ERROR, "gRPC SendLocation failed: " + status.error_message(), __FILE__, __LINE__, __func__);
-            return "RPC failed";
-        }
+        logger_.logMeta(utils::SingletonLogger::INFO,
+                        "Simulated SendLocation -> endpoint=" + endpoint_ +
+                            ", user=" + userID +
+                            ", lat=" + std::to_string(lat) +
+                            ", lon=" + std::to_string(lon),
+                        __FILE__,
+                        __LINE__,
+                        __func__);
+        return "Location acknowledged";
     }
 
 }

--- a/sharedResources/src/sharedgRPCServer.cpp
+++ b/sharedResources/src/sharedgRPCServer.cpp
@@ -1,35 +1,10 @@
 #include "../include/sharedgRPCServer.h"
-#include "../../proto/location.grpc.pb.h"
-
-#include <grpcpp/server.h>
-#include <grpcpp/server_builder.h>
-#include <grpcpp/server_context.h>
 
 namespace UberBackend
 {
-    using grpc::Server;
-    using grpc::ServerBuilder;
-    using grpc::ServerContext;
-    using grpc::Status;
-
-    class LocationServiceImpl final : public UberBackend::LocationService::Service
-    {
-    public:
-        Status SendLocation(ServerContext *context, const UberBackend::UserLocation *request, UberBackend::LocationAck *response) override
-        {
-            std::cout << "Received location for user " << request->user_id() << ": "
-                      << request->latitude() << ", " << request->longitude() << std::endl;
-
-            response->set_message("Location received");
-            return Status::OK;
-        }
-
-        // Optionally implement GetNearbyUsers here
-    };
-
     SharedgPRCServer::SharedgPRCServer(const std::string &server_address)
-        : serverAddress(server_address),
-          logger_(utils::SingletonLogger::instance())
+        : logger_(utils::SingletonLogger::instance()),
+          serverAddress_(server_address)
     {
     }
 
@@ -40,35 +15,39 @@ namespace UberBackend
 
     void SharedgPRCServer::Run()
     {
-        LocationServiceImpl service;
-
-        ServerBuilder builder;
-        builder.AddListeningPort(serverAddress, grpc::InsecureServerCredentials());
-        builder.RegisterService(&service);
-
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (running_)
         {
-            std::lock_guard<std::mutex> lock(mutex_);
-            grpcServer = builder.BuildAndStart();
-            running_.store(static_cast<bool>(grpcServer));
+            logger_.logMeta(utils::SingletonLogger::WARNING,
+                            "Attempted to start simulated gRPC server while already running",
+                            __FILE__,
+                            __LINE__,
+                            __func__);
+            return;
         }
 
-        if (grpcServer)
-        {
-            logger_.logMeta(utils::SingletonLogger::INFO, "gRPC server started on " + serverAddress, __FILE__, __LINE__, __func__);
-            grpcServer->Wait();
-        }
-
-        running_.store(false);
+        running_ = true;
+        logger_.logMeta(utils::SingletonLogger::INFO,
+                        "Simulated gRPC server started on " + serverAddress_,
+                        __FILE__,
+                        __LINE__,
+                        __func__);
     }
 
     void SharedgPRCServer::Shutdown()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
-        if (grpcServer)
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!running_)
         {
-            grpcServer->Shutdown();
-            logger_.logMeta(utils::SingletonLogger::INFO, "gRPC server shut down", __FILE__, __LINE__, __func__);
+            return;
         }
+
+        running_ = false;
+        logger_.logMeta(utils::SingletonLogger::INFO,
+                        "Simulated gRPC server shut down",
+                        __FILE__,
+                        __LINE__,
+                        __func__);
     }
 
     bool SharedgPRCServer::isRunning() const

--- a/sharedUtils/CMakeLists.txt
+++ b/sharedUtils/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.25.2)
+
+find_package(nlohmann_json CONFIG REQUIRED)
+
+add_library(uber_shared_utils
+    src/config.cpp
+    src/jwt.cpp
+    src/utils.cpp
+    src/algorithms_sha256.cpp
+)
+
+target_include_directories(uber_shared_utils
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(uber_shared_utils
+    PUBLIC
+        nlohmann_json::nlohmann_json
+)
+

--- a/sharedUtils/include/algorithms/sha256/index.h
+++ b/sharedUtils/include/algorithms/sha256/index.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace algorithms {
+
+std::string toBinary(const std::string &input);
+std::string hashComputation(const std::string &binaryData);
+
+} // namespace algorithms
+

--- a/sharedUtils/include/jwt.h
+++ b/sharedUtils/include/jwt.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <ctime>
 #include <optional>
 #include <string>
+#include <tuple>
 
 #include <utils/index.h>
-#include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
 namespace UberBackend {
     class JWTUtils {
@@ -17,6 +18,11 @@ namespace UberBackend {
         std::string refreshToken(const std::string &token, int expirySeconds = 3600);
 
     private:
+        std::string buildSignature(const std::string &userId, const std::string &salt, std::time_t expiry) const;
+        std::optional<std::tuple<std::string, std::string, std::time_t, std::string>>
+        parseToken(const std::string &token) const;
+        std::string generateSalt() const;
+
         std::string secretKey_;
         utils::SingletonLogger &logger_;
     };

--- a/sharedUtils/include/utils/index.h
+++ b/sharedUtils/include/utils/index.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <future>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace utils {
+
+class SingletonLogger {
+public:
+    enum Level {
+        DEBUG = 0,
+        INFO,
+        WARNING,
+        ERROR
+    };
+
+    static SingletonLogger &instance();
+
+    void logMeta(Level level,
+                 const std::string &message,
+                 const char *file,
+                 int line,
+                 const char *function);
+
+private:
+    SingletonLogger() = default;
+    ~SingletonLogger() = default;
+
+    std::string levelToString(Level level) const;
+
+    std::mutex mutex_;
+};
+
+class ThreadPool {
+public:
+    static ThreadPool &instance(std::size_t threadCount = std::thread::hardware_concurrency());
+
+    ThreadPool(const ThreadPool &) = delete;
+    ThreadPool &operator=(const ThreadPool &) = delete;
+
+    template <class F, class... Args>
+    auto enqueue(F &&f, Args &&... args) -> std::future<typename std::invoke_result_t<F, Args...>>
+    {
+        using ReturnType = typename std::invoke_result_t<F, Args...>;
+
+        auto task = std::make_shared<std::packaged_task<ReturnType()>>(std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+        std::future<ReturnType> res = task->get_future();
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            if (stopRequested_)
+            {
+                throw std::runtime_error("ThreadPool has been stopped");
+            }
+            tasks_.emplace([task]() { (*task)(); });
+        }
+        cv_.notify_one();
+        return res;
+    }
+
+    void shutdown();
+
+private:
+    explicit ThreadPool(std::size_t threads);
+    ~ThreadPool();
+
+    void workerLoop();
+
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool stopRequested_{false};
+};
+
+} // namespace utils
+

--- a/sharedUtils/src/algorithms_sha256.cpp
+++ b/sharedUtils/src/algorithms_sha256.cpp
@@ -1,0 +1,45 @@
+#include "../include/algorithms/sha256/index.h"
+
+#include <functional>
+#include <iomanip>
+#include <sstream>
+
+namespace algorithms {
+
+std::string toBinary(const std::string &input)
+{
+    std::string binary;
+    binary.reserve(input.size() * 8);
+    for (unsigned char ch : input)
+    {
+        for (int bit = 7; bit >= 0; --bit)
+        {
+            binary.push_back((ch & (1u << bit)) ? '1' : '0');
+        }
+    }
+    return binary;
+}
+
+std::string hashComputation(const std::string &binaryData)
+{
+    const std::string salted1 = binaryData + "::seed1";
+    const std::string salted2 = binaryData + "::seed2";
+    const std::string salted3 = binaryData + "::seed3";
+    const std::string salted4 = binaryData + "::seed4";
+
+    std::size_t h1 = std::hash<std::string>{}(salted1);
+    std::size_t h2 = std::hash<std::string>{}(salted2);
+    std::size_t h3 = std::hash<std::string>{}(salted3);
+    std::size_t h4 = std::hash<std::string>{}(salted4);
+
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (auto value : {h1, h2, h3, h4})
+    {
+        oss << std::setw(sizeof(std::size_t) * 2) << value;
+    }
+    return oss.str();
+}
+
+} // namespace algorithms
+

--- a/sharedUtils/src/jwt.cpp
+++ b/sharedUtils/src/jwt.cpp
@@ -1,6 +1,11 @@
-#include <jwt-cpp/jwt.h>
-
 #include "../include/jwt.h"
+
+#include "../include/algorithms/sha256/index.h"
+
+#include <chrono>
+#include <random>
+#include <sstream>
+#include <vector>
 
 using namespace UberBackend;
 
@@ -9,59 +14,61 @@ JWTUtils::JWTUtils(const std::string &secret)
 
 std::string JWTUtils::generateToken(const std::string &userId, int expirySeconds) {
     try {
-        // Use explicit traits if required
-        using json_traits = jwt::traits::nlohmann_json;
+        const auto now = std::chrono::system_clock::now();
+        const auto expiry = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count() + expirySeconds;
+        const std::string salt = generateSalt();
+        const std::string signature = buildSignature(userId, salt, expiry);
 
-        auto token = jwt::create<json_traits>()
-            .set_issuer("uber-backend")
-            .set_type("JWT")
-            .set_payload_claim("sub", jwt::claim(userId))
-            .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{expirySeconds})
-            .sign(jwt::algorithm::hs256{secretKey_});
-
-        return token;
+        std::ostringstream oss;
+        oss << userId << '.' << salt << '.' << expiry << '.' << signature;
+        return oss.str();
     } catch (const std::exception &e) {
-        logger_.logMeta(utils::SingletonLogger::ERROR, "JWT generation failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
+        logger_.logMeta(utils::SingletonLogger::ERROR, "Token generation failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
         return "";
     }
 }
 
 bool JWTUtils::verifyToken(const std::string &token, std::string &userId) {
-    try {
-        using json_traits = jwt::traits::nlohmann_json;
-
-        auto decoded = jwt::decode<json_traits>(token);
-
-        auto verifier = jwt::verify<json_traits>(jwt::default_clock{})
-            .allow_algorithm(jwt::algorithm::hs256{secretKey_})
-            .with_issuer("uber-backend");
-
-        verifier.verify(decoded);
-
-        if (decoded.has_payload_claim("sub")) {
-            userId = decoded.get_payload_claim("sub").as_string();
-            return true;
-        }
-    } catch (const std::exception &e) {
-        logger_.logMeta(utils::SingletonLogger::ERROR, "JWT verification failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
+    const auto parsed = parseToken(token);
+    if (!parsed.has_value()) {
+        logger_.logMeta(utils::SingletonLogger::WARNING, "Token verification failed: malformed token", __FILE__, __LINE__, __func__);
+        return false;
     }
 
-    return false;
+    const auto &[id, salt, expiry, signature] = parsed.value();
+    const std::string expectedSignature = buildSignature(id, salt, expiry);
+
+    if (expectedSignature != signature) {
+        logger_.logMeta(utils::SingletonLogger::WARNING, "Token verification failed: signature mismatch", __FILE__, __LINE__, __func__);
+        return false;
+    }
+
+    const auto now = std::chrono::system_clock::now();
+    const auto currentEpoch = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+    if (expiry < currentEpoch) {
+        logger_.logMeta(utils::SingletonLogger::WARNING, "Token verification failed: token expired", __FILE__, __LINE__, __func__);
+        return false;
+    }
+
+    userId = id;
+    return true;
 }
 
 std::optional<std::string> JWTUtils::extractSubject(const std::string &token) {
-    try {
-        using json_traits = jwt::traits::nlohmann_json;
-        auto decoded = jwt::decode<json_traits>(token);
-
-        if (decoded.has_payload_claim("sub")) {
-            return decoded.get_payload_claim("sub").as_string();
-        }
-    } catch (const std::exception &e) {
-        logger_.logMeta(utils::SingletonLogger::ERROR, "JWT decode failed: " + std::string(e.what()), __FILE__, __LINE__, __func__);
+    const auto parsed = parseToken(token);
+    if (!parsed.has_value()) {
+        logger_.logMeta(utils::SingletonLogger::WARNING, "Token subject extraction failed: malformed token", __FILE__, __LINE__, __func__);
+        return std::nullopt;
     }
 
-    return std::nullopt;
+    const auto &[id, salt, expiry, signature] = parsed.value();
+    const std::string expectedSignature = buildSignature(id, salt, expiry);
+    if (expectedSignature != signature) {
+        logger_.logMeta(utils::SingletonLogger::WARNING, "Token subject extraction failed: signature mismatch", __FILE__, __LINE__, __func__);
+        return std::nullopt;
+    }
+
+    return id;
 }
 
 std::string JWTUtils::refreshToken(const std::string &token, int expirySeconds) {
@@ -72,5 +79,61 @@ std::string JWTUtils::refreshToken(const std::string &token, int expirySeconds) 
     }
 
     return generateToken(userId, expirySeconds);
+}
+
+std::string JWTUtils::buildSignature(const std::string &userId, const std::string &salt, std::time_t expiry) const {
+    const std::string data = userId + ':' + salt + ':' + std::to_string(expiry) + ':' + secretKey_;
+    const std::string binary = algorithms::toBinary(data);
+    return algorithms::hashComputation(binary);
+}
+
+std::optional<std::tuple<std::string, std::string, std::time_t, std::string>>
+JWTUtils::parseToken(const std::string &token) const {
+    if (token.empty()) {
+        return std::nullopt;
+    }
+
+    std::vector<std::string> segments;
+    std::string current;
+    for (char ch : token) {
+        if (ch == '.') {
+            segments.push_back(current);
+            current.clear();
+        } else {
+            current.push_back(ch);
+        }
+    }
+    segments.push_back(current);
+
+    if (segments.size() != 4) {
+        return std::nullopt;
+    }
+
+    try {
+        const std::string &userId = segments[0];
+        const std::string &salt = segments[1];
+        const std::time_t expiry = static_cast<std::time_t>(std::stoll(segments[2]));
+        const std::string &signature = segments[3];
+        if (userId.empty() || salt.empty() || signature.empty()) {
+            return std::nullopt;
+        }
+        return std::make_tuple(userId, salt, expiry, signature);
+    } catch (const std::exception &) {
+        return std::nullopt;
+    }
+}
+
+std::string JWTUtils::generateSalt() const {
+    static thread_local std::mt19937_64 rng(std::random_device{}());
+    std::uniform_int_distribution<int> dist(0, 61);
+    constexpr std::size_t saltLength = 16;
+    const char alphabet[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    std::string salt;
+    salt.reserve(saltLength);
+    for (std::size_t i = 0; i < saltLength; ++i) {
+        salt.push_back(alphabet[dist(rng)]);
+    }
+    return salt;
 }
 

--- a/sharedUtils/src/utils.cpp
+++ b/sharedUtils/src/utils.cpp
@@ -1,0 +1,128 @@
+#include "../include/utils/index.h"
+
+namespace utils {
+
+namespace {
+constexpr const char *levelToColor(SingletonLogger::Level level)
+{
+    switch (level)
+    {
+    case SingletonLogger::DEBUG:
+        return "\033[36m"; // Cyan
+    case SingletonLogger::INFO:
+        return "\033[32m"; // Green
+    case SingletonLogger::WARNING:
+        return "\033[33m"; // Yellow
+    case SingletonLogger::ERROR:
+    default:
+        return "\033[31m"; // Red
+    }
+}
+
+constexpr const char *resetColor()
+{
+    return "\033[0m";
+}
+} // namespace
+
+SingletonLogger &SingletonLogger::instance()
+{
+    static SingletonLogger logger;
+    return logger;
+}
+
+void SingletonLogger::logMeta(Level level,
+                              const std::string &message,
+                              const char *file,
+                              int line,
+                              const char *function)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::ostringstream oss;
+    oss << '[' << levelToString(level) << "] " << file << ':' << line << " (" << function << ") - " << message;
+    std::cout << levelToColor(level) << oss.str() << resetColor() << std::endl;
+}
+
+std::string SingletonLogger::levelToString(Level level) const
+{
+    switch (level)
+    {
+    case DEBUG:
+        return "DEBUG";
+    case INFO:
+        return "INFO";
+    case WARNING:
+        return "WARNING";
+    case ERROR:
+    default:
+        return "ERROR";
+    }
+}
+
+ThreadPool &ThreadPool::instance(std::size_t threadCount)
+{
+    static ThreadPool pool(threadCount == 0 ? std::thread::hardware_concurrency() : threadCount);
+    return pool;
+}
+
+ThreadPool::ThreadPool(std::size_t threads)
+{
+    if (threads == 0)
+    {
+        threads = 1;
+    }
+
+    for (std::size_t i = 0; i < threads; ++i)
+    {
+        workers_.emplace_back([this]() { workerLoop(); });
+    }
+}
+
+ThreadPool::~ThreadPool()
+{
+    shutdown();
+}
+
+void ThreadPool::shutdown()
+{
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (stopRequested_)
+        {
+            return;
+        }
+        stopRequested_ = true;
+    }
+    cv_.notify_all();
+
+    for (auto &worker : workers_)
+    {
+        if (worker.joinable())
+        {
+            worker.join();
+        }
+    }
+    workers_.clear();
+}
+
+void ThreadPool::workerLoop()
+{
+    while (true)
+    {
+        std::function<void()> task;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this]() { return stopRequested_ || !tasks_.empty(); });
+            if (stopRequested_ && tasks_.empty())
+            {
+                return;
+            }
+            task = std::move(tasks_.front());
+            tasks_.pop();
+        }
+        task();
+    }
+}
+
+} // namespace utils
+


### PR DESCRIPTION
## Summary
- add shared utility and resource libraries that provide in-memory logger, thread-pool, database, Kafka, RabbitMQ, and H3 stubs so the microservices can build without external infrastructure
- replace the jwt-cpp dependency with a lightweight local token generator/validator and update each service to link only the shared stub libraries
- simplify the base Docker image and Conan recipe to install only the minimal toolchain required for local builds

## Testing
- conan build . --output-folder=build --build=missing

------
https://chatgpt.com/codex/tasks/task_e_68d650fa38e08333a9854e967e60e548