### PR TITLE
Add RideManager orchestration and integrations

### DIFF
--- a/RideManager/include/server.h
+++ b/RideManager/include/server.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+
+#include <utils/index.h>
+
+#include "./services/httpHandler/httpHandler.h"
+#include "../../sharedResources/include/sharedServer.h"
+
+namespace UberBackend
+{
+    class RideServer : public SharedServer
+    {
+    public:
+        RideServer(const std::string &serverName,
+                   const std::string &host,
+                   const std::string &user,
+                   const std::string &password,
+                   const std::string &dbName,
+                   unsigned int port);
+
+        void createHttpServers() override;
+        void startConsumers() override;
+
+    private:
+        void startKafkaConsumers();
+        void startRabbitConsumers();
+    };
+}

--- a/RideManager/include/services/httpHandler/httpHandler.h
+++ b/RideManager/include/services/httpHandler/httpHandler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+#include "../../../../sharedResources/include/sharedHTTPHandler.h"
+
+namespace UberBackend
+{
+    class HttpHandler : public SharedHttpHandler
+    {
+    public:
+        explicit HttpHandler(std::shared_ptr<SharedDatabase> db);
+        void createServers() override;
+    };
+}

--- a/RideManager/include/services/httpHandler/servers/httpRideServer.h
+++ b/RideManager/include/services/httpHandler/servers/httpRideServer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <httplib.h>
+
+#include "../../../../../sharedResources/include/sharedHTTPServer.h"
+#include "../../routeHandler/rideRouteHandler.h"
+
+namespace UberBackend
+{
+    class HttpRideServer : public SharedHttpServer
+    {
+    public:
+        HttpRideServer(const std::string &name,
+                       const std::string &host,
+                       int port,
+                       std::shared_ptr<SharedDatabase> db);
+
+        void createServerMethods() override;
+
+    private:
+        nlohmann::json parseJsonBody(const httplib::Request &req, httplib::Response &res) const;
+        void respondJson(httplib::Response &res, const nlohmann::json &payload, int status = 200) const;
+
+        std::shared_ptr<RideRouteHandler> routeHandler_;
+    };
+}

--- a/RideManager/include/services/kafkaHandler/rideKafkaManager.h
+++ b/RideManager/include/services/kafkaHandler/rideKafkaManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <utils/index.h>
+
+#include "../../../../sharedResources/include/sharedKafkaHandler.h"
+
+namespace UberBackend
+{
+    class RideKafkaManager
+    {
+    public:
+        RideKafkaManager();
+
+        void publishEvent(const std::string &eventType, const nlohmann::json &payload);
+
+    private:
+        utils::SingletonLogger &logger_;
+        std::unique_ptr<SharedKafkaHandler> handler_;
+        std::shared_ptr<SharedKafkaProducer> producer_;
+    };
+}

--- a/RideManager/include/services/location/locationGateway.h
+++ b/RideManager/include/services/location/locationGateway.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace UberBackend
+{
+    class LocationGateway
+    {
+    public:
+        LocationGateway();
+
+        std::vector<std::string> fetchNearbyDrivers(double latitude, double longitude, double radiusKm = 5.0) const;
+        std::optional<nlohmann::json> fetchLocationForUser(const std::string &userId) const;
+
+    private:
+        std::string host_;
+        int port_;
+    };
+}

--- a/RideManager/include/services/rabbitHandler/rideRabbitManager.h
+++ b/RideManager/include/services/rabbitHandler/rideRabbitManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <utils/index.h>
+
+#include "../../../../sharedResources/include/sharedRabbitMQHandler.h"
+
+namespace UberBackend
+{
+    class RideRabbitManager
+    {
+    public:
+        RideRabbitManager();
+
+        void publishDriverNotification(const std::string &driverId, const nlohmann::json &payload);
+
+    private:
+        utils::SingletonLogger &logger_;
+        std::unique_ptr<SharedRabbitMQHandler> handler_;
+        std::shared_ptr<SharedRabbitMQProducer> producer_;
+    };
+}

--- a/RideManager/include/services/routeHandler/rideRouteHandler.h
+++ b/RideManager/include/services/routeHandler/rideRouteHandler.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "../../../../sharedResources/include/sharedRouteHandler.h"
+#include "../../../../sharedResources/include/sharedgRPCClient.h"
+#include "../kafkaHandler/rideKafkaManager.h"
+#include "../location/locationGateway.h"
+#include "../rabbitHandler/rideRabbitManager.h"
+
+namespace UberBackend
+{
+    class RideRouteHandler : public SharedRouteHandler
+    {
+    public:
+        explicit RideRouteHandler(std::shared_ptr<SharedDatabase> db);
+
+        [[nodiscard]] nlohmann::json handleRideRequest(const nlohmann::json &payload);
+        [[nodiscard]] nlohmann::json handleRideStatusUpdate(const std::string &rideId, const nlohmann::json &payload);
+        [[nodiscard]] nlohmann::json handleDriverStatusUpdate(const std::string &driverId, const nlohmann::json &payload);
+        [[nodiscard]] nlohmann::json handleGetRide(const std::string &rideId) const;
+        [[nodiscard]] nlohmann::json handleGetRidesForUser(const std::string &userId) const;
+        [[nodiscard]] nlohmann::json handleGetRidesForDriver(const std::string &driverId) const;
+        [[nodiscard]] nlohmann::json handleGetDriverProfile(const std::string &driverId) const;
+
+    private:
+        enum class RideStatus
+        {
+            Requested,
+            PendingDriverDecision,
+            Accepted,
+            InProgress,
+            Completed,
+            Cancelled
+        };
+
+        struct RideRecord
+        {
+            std::string id;
+            std::string riderId;
+            std::string driverId;
+            std::string pickupAddress;
+            std::string dropoffAddress;
+            double pickupLat{0.0};
+            double pickupLng{0.0};
+            double dropoffLat{0.0};
+            double dropoffLng{0.0};
+            RideStatus status{RideStatus::Requested};
+            std::string statusReason;
+            std::string requestedAt;
+            std::string updatedAt;
+        };
+
+        struct DriverState
+        {
+            bool available{false};
+            std::string currentRideId;
+        };
+
+        [[nodiscard]] std::string generateRideId();
+        [[nodiscard]] static std::string statusToString(RideStatus status);
+        [[nodiscard]] static RideStatus statusFromString(const std::string &value);
+        [[nodiscard]] nlohmann::json rideToJson(const RideRecord &record) const;
+        [[nodiscard]] nlohmann::json buildResponse(const std::string &status,
+                                                   const std::string &message,
+                                                   int httpStatus = 200) const;
+        [[nodiscard]] nlohmann::json buildResponse(const RideRecord &record, int httpStatus = 200) const;
+
+        void setDriverAvailability(const std::string &driverId, bool available, const std::optional<std::string> &rideId = std::nullopt);
+        [[nodiscard]] bool isDriverAvailable(const std::string &driverId) const;
+        [[nodiscard]] std::optional<RideRecord> findRide(const std::string &rideId) const;
+        [[nodiscard]] std::vector<RideRecord> findRidesByPredicate(const std::function<bool(const RideRecord &)> &predicate) const;
+        [[nodiscard]] std::optional<nlohmann::json> fetchDriverProfile(const std::string &driverId) const;
+        void persistRide(const RideRecord &record) const;
+
+        utils::SingletonLogger &logger_;
+        std::unique_ptr<RideKafkaManager> kafkaManager_;
+        std::unique_ptr<RideRabbitManager> rabbitManager_;
+        std::unique_ptr<LocationGateway> locationGateway_;
+        LocationClient locationClient_;
+
+        mutable std::mutex mutex_;
+        std::unordered_map<std::string, RideRecord> rides_;
+        std::unordered_map<std::string, DriverState> drivers_;
+        std::atomic<std::uint64_t> rideSequence_;
+    };
+}

--- a/RideManager/sql_scripts/database_init.sql
+++ b/RideManager/sql_scripts/database_init.sql
@@ -40,13 +40,19 @@ CREATE TABLE IF NOT EXISTS vehicles (
 -- Rides
 CREATE TABLE IF NOT EXISTS rides (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    ride_identifier VARCHAR(64) NOT NULL UNIQUE,
     user_id INT NOT NULL,
     driver_id INT,
     pickup_location VARCHAR(255) NOT NULL,
     dropoff_location VARCHAR(255) NOT NULL,
-    start_time DATETIME,
-    end_time DATETIME,
-    status ENUM('requested', 'ongoing', 'completed', 'cancelled') DEFAULT 'requested',
+    pickup_lat DECIMAL(10, 6) DEFAULT 0,
+    pickup_lng DECIMAL(10, 6) DEFAULT 0,
+    dropoff_lat DECIMAL(10, 6) DEFAULT 0,
+    dropoff_lng DECIMAL(10, 6) DEFAULT 0,
+    requested_at DATETIME,
+    updated_at DATETIME,
+    status ENUM('requested', 'pending_driver', 'accepted', 'in_progress', 'completed', 'cancelled') DEFAULT 'requested',
+    status_reason VARCHAR(255) DEFAULT NULL,
     fare DECIMAL(10, 2),
     FOREIGN KEY (user_id) REFERENCES users(id),
     FOREIGN KEY (driver_id) REFERENCES drivers(id)

--- a/RideManager/src/server.cpp
+++ b/RideManager/src/server.cpp
@@ -1,0 +1,104 @@
+#include "../include/server.h"
+
+#include <iostream>
+
+#include "../../sharedResources/include/sharedKafkaHandler.h"
+#include "../../sharedResources/include/sharedRabbitMQConsumer.h"
+#include "../../sharedResources/include/sharedRabbitMQHandler.h"
+#include "../../sharedUtils/include/config.h"
+
+using namespace utils;
+
+namespace UberBackend
+{
+    RideServer::RideServer(const std::string &serverName,
+                           const std::string &host,
+                           const std::string &user,
+                           const std::string &password,
+                           const std::string &dbName,
+                           unsigned int port)
+        : SharedServer(serverName, host, user, password, dbName, port)
+    {
+    }
+
+    void RideServer::createHttpServers()
+    {
+        logger_.logMeta(SingletonLogger::INFO, "Initialising RideManager HTTP handlers", __FILE__, __LINE__, __func__);
+
+        httpServerHandler_ = std::make_unique<HttpHandler>(database_);
+        httpServerHandler_->createServers();
+    }
+
+    void RideServer::startConsumers()
+    {
+        startKafkaConsumers();
+        startRabbitConsumers();
+    }
+
+    void RideServer::startKafkaConsumers()
+    {
+        const auto kafkaHost = UberUtils::CONFIG::getKafkaHost();
+        const auto kafkaPort = UberUtils::CONFIG::getKafkaPort();
+
+        if (!sharedKafkaHandler_)
+        {
+            logger_.logMeta(SingletonLogger::INFO,
+                            "Bootstrapping Kafka handler for RideManager",
+                            __FILE__,
+                            __LINE__,
+                            __func__);
+            sharedKafkaHandler_ = std::make_unique<SharedKafkaHandler>(kafkaHost, std::to_string(kafkaPort));
+        }
+
+        auto rideLifecycleConsumer = sharedKafkaHandler_->createConsumer("ride_manager_lifecycle", "ride_lifecycle_events");
+        if (rideLifecycleConsumer)
+        {
+            rideLifecycleConsumer->setCallback([](const std::string &payload)
+                                               {
+                                                   std::cout << "[Kafka][RideManager] lifecycle event -> " << payload << std::endl;
+                                               });
+        }
+
+        auto locationBridgeConsumer = sharedKafkaHandler_->createConsumer("ride_manager_location_bridge", "location_events");
+        if (locationBridgeConsumer)
+        {
+            locationBridgeConsumer->setCallback([](const std::string &payload)
+                                                {
+                                                    std::cout << "[Kafka][RideManager] location update -> " << payload << std::endl;
+                                                });
+        }
+
+        sharedKafkaHandler_->runConsumers();
+    }
+
+    void RideServer::startRabbitConsumers()
+    {
+        SharedRabbitMQHandler::ConnectionOptions options{
+            UberUtils::CONFIG::getRabbitMQHost(),
+            std::to_string(UberUtils::CONFIG::getRabbitMQPort()),
+            UberUtils::CONFIG::getRabbitMQUsername(),
+            UberUtils::CONFIG::getRabbitMQPassword(),
+            UberUtils::CONFIG::getRabbitMQVHost()};
+
+        if (!sharedRabbitHandler_)
+        {
+            logger_.logMeta(SingletonLogger::INFO,
+                            "Initialising RabbitMQ handler for RideManager",
+                            __FILE__,
+                            __LINE__,
+                            __func__);
+            sharedRabbitHandler_ = std::make_unique<SharedRabbitMQHandler>(options);
+        }
+
+        auto driverTaskConsumer = sharedRabbitHandler_->createConsumer("ride_manager_driver_tasks", "driver_notifications");
+        if (driverTaskConsumer)
+        {
+            driverTaskConsumer->setCallback([](const std::string &message)
+                                            {
+                                                std::cout << "[RabbitMQ][RideManager] driver task -> " << message << std::endl;
+                                            });
+        }
+
+        sharedRabbitHandler_->runConsumers();
+    }
+}

--- a/RideManager/src/services/httpHandler/httpHandler.cpp
+++ b/RideManager/src/services/httpHandler/httpHandler.cpp
@@ -1,0 +1,31 @@
+#include "../../../include/services/httpHandler/httpHandler.h"
+
+#include <memory>
+
+#include "../../../include/services/httpHandler/servers/httpRideServer.h"
+#include "../../../../sharedUtils/include/config.h"
+
+namespace UberBackend
+{
+    HttpHandler::HttpHandler(std::shared_ptr<SharedDatabase> db)
+        : SharedHttpHandler(std::move(db))
+    {
+    }
+
+    void HttpHandler::createServers()
+    {
+        logger_.logMeta(utils::SingletonLogger::INFO,
+                        "Creating RideManager HTTP server",
+                        __FILE__,
+                        __LINE__,
+                        __func__);
+
+        auto rideServer = std::make_unique<HttpRideServer>(
+            "ride_http_handler",
+            UberUtils::CONFIG::getRideManagerHost(),
+            static_cast<int>(UberUtils::CONFIG::getRideManagerHttpPort()),
+            database_);
+        rideServer->createServerMethods();
+        servers_.push_back(std::move(rideServer));
+    }
+}

--- a/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
+++ b/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
@@ -1,0 +1,127 @@
+#include "../../../include/services/httpHandler/servers/httpRideServer.h"
+
+#include <algorithm>
+#include <optional>
+
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+
+namespace UberBackend
+{
+    HttpRideServer::HttpRideServer(const std::string &name,
+                                   const std::string &host,
+                                   int port,
+                                   std::shared_ptr<SharedDatabase> db)
+        : SharedHttpServer(name, host, port, std::move(db)),
+          routeHandler_(std::make_shared<RideRouteHandler>(database_))
+    {
+    }
+
+    json HttpRideServer::parseJsonBody(const httplib::Request &req, httplib::Response &res) const
+    {
+        if (req.body.empty())
+        {
+            respondJson(res, json{{"status", "error"}, {"message", "Empty request body"}}, 400);
+            return {};
+        }
+
+        json payload = json::parse(req.body, nullptr, false);
+        if (payload.is_discarded())
+        {
+            respondJson(res, json{{"status", "error"}, {"message", "Invalid JSON payload"}}, 400);
+            return {};
+        }
+
+        return payload;
+    }
+
+    void HttpRideServer::respondJson(httplib::Response &res, const json &payload, int status) const
+    {
+        res.status = status;
+        res.set_content(payload.dump(), "application/json");
+    }
+
+    void HttpRideServer::createServerMethods()
+    {
+        server_->Post("/rides/request", [this](const httplib::Request &req, httplib::Response &res)
+                      {
+                          auto payload = parseJsonBody(req, res);
+                          if (payload.empty())
+                          {
+                              return;
+                          }
+
+                          auto result = routeHandler_->handleRideRequest(payload);
+                          int statusCode = result.value("http_status", 500);
+                          result.erase("http_status");
+                          respondJson(res, result, statusCode);
+                      });
+
+        server_->Post(R"(/rides/(\w+)/status)", [this](const httplib::Request &req, httplib::Response &res)
+                      {
+                          auto payload = parseJsonBody(req, res);
+                          if (payload.empty())
+                          {
+                              return;
+                          }
+
+                          const std::string rideId = req.matches[1];
+                          auto result = routeHandler_->handleRideStatusUpdate(rideId, payload);
+                          int statusCode = result.value("http_status", 500);
+                          result.erase("http_status");
+                          respondJson(res, result, statusCode);
+                      });
+
+        server_->Post(R"(/drivers/(\w+)/status)", [this](const httplib::Request &req, httplib::Response &res)
+                      {
+                          auto payload = parseJsonBody(req, res);
+                          if (payload.empty())
+                          {
+                              return;
+                          }
+
+                          const std::string driverId = req.matches[1];
+                          auto result = routeHandler_->handleDriverStatusUpdate(driverId, payload);
+                          int statusCode = result.value("http_status", 500);
+                          result.erase("http_status");
+                          respondJson(res, result, statusCode);
+                      });
+
+        server_->Get(R"(/rides/(\w+))", [this](const httplib::Request &req, httplib::Response &res)
+                    {
+                        const std::string rideId = req.matches[1];
+                        auto result = routeHandler_->handleGetRide(rideId);
+                        int statusCode = result.value("http_status", 500);
+                        result.erase("http_status");
+                        respondJson(res, result, statusCode);
+                    });
+
+        server_->Get(R"(/rides/user/(\w+))", [this](const httplib::Request &req, httplib::Response &res)
+                    {
+                        const std::string userId = req.matches[1];
+                        auto result = routeHandler_->handleGetRidesForUser(userId);
+                        int statusCode = result.value("http_status", 500);
+                        result.erase("http_status");
+                        respondJson(res, result, statusCode);
+                    });
+
+        server_->Get(R"(/rides/driver/(\w+))", [this](const httplib::Request &req, httplib::Response &res)
+                    {
+                        const std::string driverId = req.matches[1];
+                        auto result = routeHandler_->handleGetRidesForDriver(driverId);
+                        int statusCode = result.value("http_status", 500);
+                        result.erase("http_status");
+                        respondJson(res, result, statusCode);
+                    });
+
+        server_->Get(R"(/drivers/(\w+)/profile)", [this](const httplib::Request &req, httplib::Response &res)
+                    {
+                        const std::string driverId = req.matches[1];
+                        auto result = routeHandler_->handleGetDriverProfile(driverId);
+                        int statusCode = result.value("http_status", 500);
+                        result.erase("http_status");
+                        respondJson(res, result, statusCode);
+                    });
+    }
+}

--- a/RideManager/src/services/kafkaHandler/rideKafkaManager.cpp
+++ b/RideManager/src/services/kafkaHandler/rideKafkaManager.cpp
@@ -1,0 +1,42 @@
+#include "../../../include/services/kafkaHandler/rideKafkaManager.h"
+
+#include <sstream>
+
+#include "../../../../sharedUtils/include/config.h"
+
+namespace UberBackend
+{
+    namespace
+    {
+        constexpr const char *kTopic = "ride_lifecycle_events";
+    }
+
+    RideKafkaManager::RideKafkaManager()
+        : logger_(utils::SingletonLogger::instance())
+    {
+        handler_ = std::make_unique<SharedKafkaHandler>(
+            UberUtils::CONFIG::getKafkaHost(),
+            std::to_string(UberUtils::CONFIG::getKafkaPort()));
+        producer_ = handler_->createProducer("ride_manager_producer");
+
+        if (!producer_)
+        {
+            logger_.logMeta(utils::SingletonLogger::WARNING,
+                            "Failed to create Kafka producer for ride events",
+                            __FILE__,
+                            __LINE__,
+                            __func__);
+        }
+    }
+
+    void RideKafkaManager::publishEvent(const std::string &eventType, const nlohmann::json &payload)
+    {
+        if (!producer_)
+        {
+            return;
+        }
+
+        nlohmann::json envelope{{"type", eventType}, {"payload", payload}, {"source", "RideManager"}};
+        producer_->sendMessage(kTopic, envelope.dump());
+    }
+}

--- a/RideManager/src/services/location/locationGateway.cpp
+++ b/RideManager/src/services/location/locationGateway.cpp
@@ -1,0 +1,77 @@
+#include "../../../include/services/location/locationGateway.h"
+
+#include <sstream>
+
+#include <httplib.h>
+
+#include "../../../../sharedUtils/include/config.h"
+
+namespace UberBackend
+{
+    LocationGateway::LocationGateway()
+    {
+        host_ = UberUtils::CONFIG::getLocationManagerHost();
+        port_ = static_cast<int>(UberUtils::CONFIG::getLocationManagerHttpPort());
+    }
+
+    std::vector<std::string> LocationGateway::fetchNearbyDrivers(double latitude, double longitude, double radiusKm) const
+    {
+        httplib::Client client(host_, port_);
+        std::stringstream path;
+        path << "/location/nearby?lat=" << latitude << "&lng=" << longitude << "&radius=" << radiusKm << "&role=driver";
+
+        auto response = client.Get(path.str().c_str());
+        if (!response || response->status >= 400)
+        {
+            return {};
+        }
+
+        nlohmann::json payload = nlohmann::json::parse(response->body, nullptr, false);
+        if (payload.is_discarded())
+        {
+            return {};
+        }
+
+        std::vector<std::string> drivers;
+        if (payload.contains("data") && payload.at("data").is_array())
+        {
+            for (const auto &entry : payload.at("data"))
+            {
+                if (entry.contains("user_id"))
+                {
+                    drivers.push_back(entry.at("user_id").get<std::string>());
+                }
+            }
+        }
+        else if (payload.contains("users") && payload.at("users").is_array())
+        {
+            for (const auto &entry : payload.at("users"))
+            {
+                if (entry.contains("user_id"))
+                {
+                    drivers.push_back(entry.at("user_id").get<std::string>());
+                }
+            }
+        }
+
+        return drivers;
+    }
+
+    std::optional<nlohmann::json> LocationGateway::fetchLocationForUser(const std::string &userId) const
+    {
+        httplib::Client client(host_, port_);
+        auto response = client.Get(("/location/" + userId).c_str());
+        if (!response || response->status >= 400)
+        {
+            return std::nullopt;
+        }
+
+        nlohmann::json payload = nlohmann::json::parse(response->body, nullptr, false);
+        if (payload.is_discarded())
+        {
+            return std::nullopt;
+        }
+
+        return payload;
+    }
+}

--- a/RideManager/src/services/rabbitHandler/rideRabbitManager.cpp
+++ b/RideManager/src/services/rabbitHandler/rideRabbitManager.cpp
@@ -1,0 +1,45 @@
+#include "../../../include/services/rabbitHandler/rideRabbitManager.h"
+
+#include "../../../../sharedUtils/include/config.h"
+
+namespace UberBackend
+{
+    namespace
+    {
+        constexpr const char *kQueueName = "driver_notifications";
+    }
+
+    RideRabbitManager::RideRabbitManager()
+        : logger_(utils::SingletonLogger::instance())
+    {
+        SharedRabbitMQHandler::ConnectionOptions options{
+            UberUtils::CONFIG::getRabbitMQHost(),
+            std::to_string(UberUtils::CONFIG::getRabbitMQPort()),
+            UberUtils::CONFIG::getRabbitMQUsername(),
+            UberUtils::CONFIG::getRabbitMQPassword(),
+            UberUtils::CONFIG::getRabbitMQVHost()};
+
+        handler_ = std::make_unique<SharedRabbitMQHandler>(options);
+        producer_ = handler_->createProducer("ride_manager_driver_notifications", kQueueName);
+
+        if (!producer_)
+        {
+            logger_.logMeta(utils::SingletonLogger::WARNING,
+                            "Failed to create RabbitMQ producer for driver notifications",
+                            __FILE__,
+                            __LINE__,
+                            __func__);
+        }
+    }
+
+    void RideRabbitManager::publishDriverNotification(const std::string &driverId, const nlohmann::json &payload)
+    {
+        if (!producer_)
+        {
+            return;
+        }
+
+        nlohmann::json envelope{{"driver_id", driverId}, {"payload", payload}};
+        producer_->publish(envelope.dump());
+    }
+}

--- a/RideManager/src/services/routeHandler/rideRouteHandler.cpp
+++ b/RideManager/src/services/routeHandler/rideRouteHandler.cpp
@@ -1,0 +1,458 @@
+#include "../../../include/services/routeHandler/rideRouteHandler.h"
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <utility>
+
+#include <httplib.h>
+
+#include "../../../../sharedUtils/include/config.h"
+
+namespace
+{
+    std::string currentTimestamp()
+    {
+        using clock = std::chrono::system_clock;
+        auto now = clock::now();
+        std::time_t timeNow = clock::to_time_t(now);
+        std::tm tm{};
+#ifdef _WIN32
+        localtime_s(&tm, &timeNow);
+#else
+        localtime_r(&timeNow, &tm);
+#endif
+        std::ostringstream oss;
+        oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
+        return oss.str();
+    }
+}
+
+namespace UberBackend
+{
+    RideRouteHandler::RideRouteHandler(std::shared_ptr<SharedDatabase> db)
+        : SharedRouteHandler(std::move(db)),
+          logger_(utils::SingletonLogger::instance()),
+          kafkaManager_(std::make_unique<RideKafkaManager>()),
+          rabbitManager_(std::make_unique<RideRabbitManager>()),
+          locationGateway_(std::make_unique<LocationGateway>()),
+          locationClient_(UberUtils::CONFIG::getLocationManagerHost() + ":" + std::to_string(UberUtils::CONFIG::getLocationManagerGrpcPort())),
+          rideSequence_(1)
+    {
+    }
+
+    std::string RideRouteHandler::generateRideId()
+    {
+        const auto seq = rideSequence_.fetch_add(1);
+        std::ostringstream oss;
+        oss << "ride-" << std::setfill('0') << std::setw(8) << seq;
+        return oss.str();
+    }
+
+    std::string RideRouteHandler::statusToString(RideStatus status)
+    {
+        switch (status)
+        {
+        case RideStatus::Requested:
+            return "requested";
+        case RideStatus::PendingDriverDecision:
+            return "pending_driver";
+        case RideStatus::Accepted:
+            return "accepted";
+        case RideStatus::InProgress:
+            return "in_progress";
+        case RideStatus::Completed:
+            return "completed";
+        case RideStatus::Cancelled:
+        default:
+            return "cancelled";
+        }
+    }
+
+    RideRouteHandler::RideStatus RideRouteHandler::statusFromString(const std::string &value)
+    {
+        if (value == "requested")
+        {
+            return RideStatus::Requested;
+        }
+        if (value == "pending_driver")
+        {
+            return RideStatus::PendingDriverDecision;
+        }
+        if (value == "accepted")
+        {
+            return RideStatus::Accepted;
+        }
+        if (value == "in_progress")
+        {
+            return RideStatus::InProgress;
+        }
+        if (value == "completed")
+        {
+            return RideStatus::Completed;
+        }
+        return RideStatus::Cancelled;
+    }
+
+    nlohmann::json RideRouteHandler::rideToJson(const RideRecord &record) const
+    {
+        nlohmann::json payload{{"ride_id", record.id},
+                               {"rider_id", record.riderId},
+                               {"driver_id", record.driverId},
+                               {"pickup", { {"address", record.pickupAddress}, {"lat", record.pickupLat}, {"lng", record.pickupLng} }},
+                               {"dropoff", { {"address", record.dropoffAddress}, {"lat", record.dropoffLat}, {"lng", record.dropoffLng} }},
+                               {"status", statusToString(record.status)},
+                               {"requested_at", record.requestedAt},
+                               {"updated_at", record.updatedAt}};
+
+        if (!record.statusReason.empty())
+        {
+            payload["status_reason"] = record.statusReason;
+        }
+
+        return payload;
+    }
+
+    nlohmann::json RideRouteHandler::buildResponse(const std::string &status,
+                                                   const std::string &message,
+                                                   int httpStatus) const
+    {
+        return nlohmann::json{{"status", status}, {"message", message}, {"http_status", httpStatus}};
+    }
+
+    nlohmann::json RideRouteHandler::buildResponse(const RideRecord &record, int httpStatus) const
+    {
+        auto payload = rideToJson(record);
+        payload["status"] = "success";
+        payload["http_status"] = httpStatus;
+        return payload;
+    }
+
+    void RideRouteHandler::setDriverAvailability(const std::string &driverId, bool available, const std::optional<std::string> &rideId)
+    {
+        std::scoped_lock lock(mutex_);
+        auto &state = drivers_[driverId];
+        state.available = available;
+        if (available)
+        {
+            state.currentRideId.clear();
+        }
+        else if (rideId)
+        {
+            state.currentRideId = *rideId;
+        }
+    }
+
+    bool RideRouteHandler::isDriverAvailable(const std::string &driverId) const
+    {
+        std::scoped_lock lock(mutex_);
+        auto it = drivers_.find(driverId);
+        return it == drivers_.end() ? false : it->second.available && it->second.currentRideId.empty();
+    }
+
+    std::optional<RideRouteHandler::RideRecord> RideRouteHandler::findRide(const std::string &rideId) const
+    {
+        std::scoped_lock lock(mutex_);
+        auto it = rides_.find(rideId);
+        if (it == rides_.end())
+        {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    std::vector<RideRouteHandler::RideRecord> RideRouteHandler::findRidesByPredicate(const std::function<bool(const RideRecord &)> &predicate) const
+    {
+        std::vector<RideRecord> results;
+        std::scoped_lock lock(mutex_);
+        for (const auto &[id, record] : rides_)
+        {
+            if (predicate(record))
+            {
+                results.push_back(record);
+            }
+        }
+        return results;
+    }
+
+    std::optional<nlohmann::json> RideRouteHandler::fetchDriverProfile(const std::string &driverId) const
+    {
+        httplib::Client client(UberUtils::CONFIG::getUserManagerHost(), static_cast<int>(UberUtils::CONFIG::getUserManagerHttpPort()));
+        auto response = client.Get(("/user/" + driverId).c_str());
+        if (!response || response->status >= 400)
+        {
+            return std::nullopt;
+        }
+
+        nlohmann::json payload = nlohmann::json::parse(response->body, nullptr, false);
+        if (payload.is_discarded())
+        {
+            return std::nullopt;
+        }
+
+        return payload;
+    }
+
+    void RideRouteHandler::persistRide(const RideRecord &record) const
+    {
+        if (!database_)
+        {
+            return;
+        }
+
+        auto toInteger = [](const std::string &value) -> long long
+        {
+            try
+            {
+                return std::stoll(value);
+            }
+            catch (...)
+            {
+                return 0;
+            }
+        };
+
+        std::ostringstream query;
+        query << "INSERT INTO rides(ride_identifier, user_id, driver_id, pickup_location, dropoff_location, pickup_lat, pickup_lng, dropoff_lat, dropoff_lng, requested_at, updated_at, status, status_reason) VALUES ("
+              << "'" << database_->escapeString(record.id) << "',"
+              << toInteger(record.riderId) << ","
+              << (record.driverId.empty() ? std::string("NULL") : std::to_string(toInteger(record.driverId))) << ","
+              << "'" << database_->escapeString(record.pickupAddress) << "',"
+              << "'" << database_->escapeString(record.dropoffAddress) << "',"
+              << record.pickupLat << ","
+              << record.pickupLng << ","
+              << record.dropoffLat << ","
+              << record.dropoffLng << ","
+              << "'" << database_->escapeString(record.requestedAt) << "',"
+              << "'" << database_->escapeString(record.updatedAt) << "',"
+              << "'" << database_->escapeString(statusToString(record.status)) << "',"
+              << "'" << database_->escapeString(record.statusReason) << "')"
+              << " ON DUPLICATE KEY UPDATE status='" << database_->escapeString(statusToString(record.status)) << "',"
+              << " status_reason='" << database_->escapeString(record.statusReason) << "',"
+              << " updated_at='" << database_->escapeString(record.updatedAt) << "'";
+
+        database_->executeInsert(query.str());
+    }
+
+    nlohmann::json RideRouteHandler::handleRideRequest(const nlohmann::json &payload)
+    {
+        const std::vector<std::string> requiredFields{"rider_id", "pickup_location", "dropoff_location"};
+        for (const auto &field : requiredFields)
+        {
+            if (!payload.contains(field) || payload.at(field).is_null())
+            {
+                return buildResponse("error", "Missing field: " + field, 400);
+            }
+        }
+
+        const std::string riderId = payload.at("rider_id").get<std::string>();
+        const std::string pickup = payload.at("pickup_location").get<std::string>();
+        const std::string dropoff = payload.at("dropoff_location").get<std::string>();
+        const double pickupLat = payload.value("pickup_lat", 0.0);
+        const double pickupLng = payload.value("pickup_lng", 0.0);
+        const double dropoffLat = payload.value("dropoff_lat", 0.0);
+        const double dropoffLng = payload.value("dropoff_lng", 0.0);
+
+        std::vector<std::string> nearbyDrivers;
+        if (locationGateway_)
+        {
+            nearbyDrivers = locationGateway_->fetchNearbyDrivers(pickupLat, pickupLng);
+        }
+
+        std::string selectedDriver;
+        for (const auto &candidate : nearbyDrivers)
+        {
+            if (isDriverAvailable(candidate))
+            {
+                selectedDriver = candidate;
+                break;
+            }
+        }
+
+        if (selectedDriver.empty())
+        {
+            // fallback to any available driver tracked by state
+            std::scoped_lock lock(mutex_);
+            for (const auto &[driverId, state] : drivers_)
+            {
+                if (state.available && state.currentRideId.empty())
+                {
+                    selectedDriver = driverId;
+                    break;
+                }
+            }
+        }
+
+        if (selectedDriver.empty())
+        {
+            return buildResponse("error", "No drivers currently available", 409);
+        }
+
+        RideRecord record;
+        record.id = generateRideId();
+        record.riderId = riderId;
+        record.driverId = selectedDriver;
+        record.pickupAddress = pickup;
+        record.dropoffAddress = dropoff;
+        record.pickupLat = pickupLat;
+        record.pickupLng = pickupLng;
+        record.dropoffLat = dropoffLat;
+        record.dropoffLng = dropoffLng;
+        record.status = RideStatus::PendingDriverDecision;
+        record.requestedAt = currentTimestamp();
+        record.updatedAt = record.requestedAt;
+
+        {
+            std::scoped_lock lock(mutex_);
+            rides_[record.id] = record;
+        }
+
+        setDriverAvailability(selectedDriver, false, record.id);
+        persistRide(record);
+
+        auto rideJson = rideToJson(record);
+        kafkaManager_->publishEvent("ride.requested", rideJson);
+        kafkaManager_->publishEvent("ride.assigned", rideJson);
+        rabbitManager_->publishDriverNotification(selectedDriver, rideJson);
+        locationClient_.SendLocation(riderId, pickupLat, pickupLng);
+
+        return buildResponse(record, 201);
+    }
+
+    nlohmann::json RideRouteHandler::handleRideStatusUpdate(const std::string &rideId, const nlohmann::json &payload)
+    {
+        if (!payload.contains("status"))
+        {
+            return buildResponse("error", "Missing status field", 400);
+        }
+
+        auto rideOpt = findRide(rideId);
+        if (!rideOpt)
+        {
+            return buildResponse("error", "Ride not found", 404);
+        }
+
+        RideRecord record = *rideOpt;
+        const std::string statusValue = payload.at("status").get<std::string>();
+        RideStatus newStatus = statusFromString(statusValue);
+        record.updatedAt = currentTimestamp();
+
+        switch (newStatus)
+        {
+        case RideStatus::Accepted:
+            record.status = RideStatus::Accepted;
+            setDriverAvailability(record.driverId, false, rideId);
+            record.statusReason = payload.value("reason", std::string{});
+            break;
+        case RideStatus::InProgress:
+            record.status = RideStatus::InProgress;
+            record.statusReason.clear();
+            break;
+        case RideStatus::Completed:
+            record.status = RideStatus::Completed;
+            record.statusReason = payload.value("fare", std::string{});
+            setDriverAvailability(record.driverId, true);
+            break;
+        case RideStatus::Cancelled:
+            record.status = RideStatus::Cancelled;
+            record.statusReason = payload.value("reason", std::string{});
+            setDriverAvailability(record.driverId, true);
+            break;
+        case RideStatus::PendingDriverDecision:
+        case RideStatus::Requested:
+        default:
+            record.status = newStatus;
+            break;
+        }
+
+        {
+            std::scoped_lock lock(mutex_);
+            rides_[rideId] = record;
+        }
+
+        persistRide(record);
+
+        auto rideJson = rideToJson(record);
+        kafkaManager_->publishEvent("ride.status_changed", rideJson);
+        if (!record.driverId.empty())
+        {
+            rabbitManager_->publishDriverNotification(record.driverId, rideJson);
+        }
+
+        return buildResponse(record);
+    }
+
+    nlohmann::json RideRouteHandler::handleDriverStatusUpdate(const std::string &driverId, const nlohmann::json &payload)
+    {
+        bool available = payload.value("available", false);
+        std::optional<std::string> rideId;
+        if (payload.contains("ride_id") && payload.at("ride_id").is_string())
+        {
+            rideId = payload.at("ride_id").get<std::string>();
+        }
+
+        setDriverAvailability(driverId, available, rideId);
+
+        nlohmann::json driverState{{"driver_id", driverId}, {"available", available}};
+        if (rideId)
+        {
+            driverState["ride_id"] = *rideId;
+        }
+
+        kafkaManager_->publishEvent("driver.status_changed", driverState);
+        return nlohmann::json{{"status", "success"}, {"message", "Driver status updated"}, {"http_status", 200}, {"data", driverState}};
+    }
+
+    nlohmann::json RideRouteHandler::handleGetRide(const std::string &rideId) const
+    {
+        auto rideOpt = findRide(rideId);
+        if (!rideOpt)
+        {
+            return buildResponse("error", "Ride not found", 404);
+        }
+
+        return buildResponse(*rideOpt);
+    }
+
+    nlohmann::json RideRouteHandler::handleGetRidesForUser(const std::string &userId) const
+    {
+        auto results = findRidesByPredicate([&userId](const RideRecord &record)
+                                            { return record.riderId == userId; });
+
+        nlohmann::json response{{"status", "success"}, {"http_status", 200}};
+        response["data"] = nlohmann::json::array();
+        for (const auto &record : results)
+        {
+            response["data"].push_back(rideToJson(record));
+        }
+        return response;
+    }
+
+    nlohmann::json RideRouteHandler::handleGetRidesForDriver(const std::string &driverId) const
+    {
+        auto results = findRidesByPredicate([&driverId](const RideRecord &record)
+                                            { return record.driverId == driverId; });
+
+        nlohmann::json response{{"status", "success"}, {"http_status", 200}};
+        response["data"] = nlohmann::json::array();
+        for (const auto &record : results)
+        {
+            response["data"].push_back(rideToJson(record));
+        }
+        return response;
+    }
+
+    nlohmann::json RideRouteHandler::handleGetDriverProfile(const std::string &driverId) const
+    {
+        auto profile = fetchDriverProfile(driverId);
+        if (!profile)
+        {
+            return buildResponse("error", "Driver not found", 404);
+        }
+
+        nlohmann::json response{{"status", "success"}, {"http_status", 200}};
+        response["data"] = *profile;
+        return response;
+    }
+}

--- a/sharedUtils/include/config.h
+++ b/sharedUtils/include/config.h
@@ -128,6 +128,26 @@ namespace UberBackend
                 return ConfigManager::instance().getUnsigned("USER_MANAGER_HTTP_USER_HANDLER_PORT", USER_MANAGER_HTTP_USER_HANDLER_PORT);
             }
 
+            static std::string getLocationManagerHost()
+            {
+                return ConfigManager::instance().getString("LOCATION_MANAGER_HOST", LOCATION_MANAGER_HOST);
+            }
+
+            static std::string getLocationManagerDatabase()
+            {
+                return ConfigManager::instance().getString("LOCATION_MANAGER_DATABASE_NAME", LOCATION_MANAGER_DATABASE_NAME);
+            }
+
+            static unsigned int getLocationManagerDatabasePort()
+            {
+                return ConfigManager::instance().getUnsigned("LOCATION_MANAGER_DATABASE_PORT", LOCATION_MANAGER_DATABASE_PORT);
+            }
+
+            static unsigned int getLocationManagerHttpPort()
+            {
+                return ConfigManager::instance().getUnsigned("LOCATION_MANAGER_HTTP_LOCATION_HANDLER_PORT", LOCATION_MANAGER_HTTP_LOCATION_HANDLER_PORT);
+            }
+
             static std::string getKafkaHost()
             {
                 return ConfigManager::instance().getString("KAFKA_HOST", KAFKA_HOST);
@@ -141,6 +161,36 @@ namespace UberBackend
             static unsigned int getLocationManagerGrpcPort()
             {
                 return ConfigManager::instance().getUnsigned("LOCATION_MANAGER_GRPC_PORT", LOCATION_MANAGER_GRPC_PORT);
+            }
+
+            static std::string getRideManagerHost()
+            {
+                return ConfigManager::instance().getString("RIDE_MANAGER_HOST", RIDE_MANAGER_HOST);
+            }
+
+            static unsigned int getRideManagerDatabasePort()
+            {
+                return ConfigManager::instance().getUnsigned("RIDE_MANAGER_DATABASE_PORT", RIDE_MANAGER_DATABASE_PORT);
+            }
+
+            static std::string getRideManagerDatabase()
+            {
+                return ConfigManager::instance().getString("RIDE_MANAGER_DATABASE_NAME", RIDE_MANAGER_DATABASE_NAME);
+            }
+
+            static std::string getRideManagerUsername()
+            {
+                return ConfigManager::instance().getString("RIDE_MANAGER_USERNAME", RIDE_MANAGER_USERNAME);
+            }
+
+            static std::string getRideManagerPassword()
+            {
+                return ConfigManager::instance().getString("RIDE_MANAGER_PASSWORD", RIDE_MANAGER_PASSWORD);
+            }
+
+            static unsigned int getRideManagerHttpPort()
+            {
+                return ConfigManager::instance().getUnsigned("RIDE_MANAGER_HTTP_RIDE_HANDLER_PORT", RIDE_MANAGER_HTTP_RIDE_HANDLER_PORT);
             }
 
             static std::string getRabbitMQHost()


### PR DESCRIPTION
## Summary
- replace the RideManager stub with a full server that boots HTTP handlers, Kafka consumers, and RabbitMQ consumers
- add ride routing, Kafka/Rabbit producers, and location gateway helpers to handle ride lifecycle, driver availability, and profile lookups
- expose additional configuration getters and extend the ride schema to persist enriched lifecycle metadata

## Testing
- cmake -S . -B build *(fails: missing `nlohmann_json` package in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d675f2225883338fb148fe670c77af