### PR TITLE
Fix RideManager includes for successful Conan build

### DIFF
--- a/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
+++ b/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
@@ -1,4 +1,4 @@
-#include "../../../include/services/httpHandler/servers/httpRideServer.h"
+#include "../../../../include/services/httpHandler/servers/httpRideServer.h"
 
 #include <algorithm>
 #include <optional>

--- a/RideManager/src/services/rabbitHandler/rideRabbitManager.cpp
+++ b/RideManager/src/services/rabbitHandler/rideRabbitManager.cpp
@@ -1,5 +1,6 @@
 #include "../../../include/services/rabbitHandler/rideRabbitManager.h"
 
+#include "../../../../sharedResources/include/sharedRabbitMQProducer.h"
 #include "../../../../sharedUtils/include/config.h"
 
 namespace UberBackend


### PR DESCRIPTION
## Summary
- correct the RideManager HTTP server include path so headers resolve during builds
- include the RabbitMQ producer definition to allow publishing driver notifications

## Testing
- `conan build . --output-folder=build --build=missing`


------
https://chatgpt.com/codex/tasks/task_e_68d67a0f90c48333ab8b7e5a29a49fb7