### PR TITLE
Add automation test overview report

### DIFF
--- a/codex automation test/version 01/README.md
+++ b/codex automation test/version 01/README.md
@@ -1,0 +1,6 @@
+# Automation Test Overview
+
+- Build executed with `conan build . --output-folder=build --build=missing`, producing UserManager, RideManager, and LocationManager binaries.
+- Docker CLI is unavailable in the environment (`docker --version` is not installed), so containerized dependencies (Kafka, RabbitMQ, databases) could not be provisioned.
+- Runtime validation and the scenarios defined in `docs/system_validation_scenarios.md` remain unexecuted because the required infrastructure could not be started.
+- Generated `test_overview_report.pdf` summarizing the build status and blockers.

--- a/codex automation test/version 01/test_overview_report.pdf
+++ b/codex automation test/version 01/test_overview_report.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250926124254+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250926124254+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1421
+>>
+stream
+Gat=*gMYb*&:O"Kb[[r\D!U(bJ1cq.ZPRG`9bXE8MZ=&PN?-T5.$0Zln(7#i(4F#"fgZ8*^m$sJF3^:a#Qso2h'XiU0':O\22!Z8q#\F/Qb`M+0'D]YGm**ISPOU[r]G!`$kjJu':9STEhB(X$cZ7MAoM&q=YM(2$$4T#5-7\a"hpMDr%$!@g-qp@To0s67X&"MF+0L!i9I#K2bJNfDU*\^oKe;\FP)7+.Xh$i4^8AtUp_RjeAm+N"&-RKJA\bo>PVqhDUMj?6XF[c&d=uIMQ0#[_mg!h%AI8bQj1roW'!_IZXND`gs9X#ouGN6og^(3:T4M(XKb.C@0>?-(RBu<)2,@4Gm4UY-;)ea"#+5hW!mWJ)Fe@3r.>kt=QOR%?thm$W@N:U8AfAE\BkMLjL'Dl=_ld0W@*5[%ZCfIl^D>*P`WK.rjtbW!NtD&$hY8cWJ-IL"#gQ;VVHR3*P::W'/7U@M&*F'@('YkB5*AK9'F#\[F,fMfWRm*O6K^(4h,H-'9_ts9.j%>$n_'."a^jD\K-:?dl*C9.j=1HK3efo-^CVO:1&Q))L$`bo[;S3Hrh*f;k(6@Q:sFH:YaL6eQNK85h;g49sB_)L?dgm4:'aBO+kqaPfkH$2<Tc5&p3;^%]Q[1H,UV`M.c&2jIU2KR[%]Gl3#h!%!Q'],^0T/%N\@g(ZhZjJEe?;(R<(`RSYH41t8rPpheSGdE1&46Wh:?5s$=5YR;[IiYhP\P*QeeQ><1)Bd^%c/^a2Mg?e)8&Cb?<,\-G)G.nor`-k,'h,Cc\AJ!4?dId>CJtFW6Klr)IRW\Ztcd>)1AObs=qpM;t&h53Z_M3\-fj_pV30pGY>^tVA%J^`3)7e#;RPZRkU1^^>PkN<':Qhu`EGK7T9Z<2J9Z:Mfe88J0=te5>D(!M`LRtIQjK,6(/Leqr"PR+.e_#]_!j/.pPRGI;;)L;?6=T7F@,?=GH8tl]!YL1S&1!ht0'h<_$E;4L9J\=s-`!:8H1^#J$**5r(NMrE'B$G6'2<Op_RRd$O$gZam[A"P/jD2"*=s<;rpD\5p)pG\o^-i;@BR-R.:GL?djXFoG&KV5hgX@![N^>kr*$^n-D#(h<_;ki)iVcLJZ^Ml9FF`eY`ehnVa><-P3T"4?7BPQBV^JmYn4(dp;CIeZf@4YCSrR!FeL3U4@SGUL]ug.^R^iB52Jre*MO^dL/&bPSWN^(%dDHFE&qN4-7g/gVq74QQ:S0p?56l_G.F25"-;Cm=s'Q.F?8X4B/g@p*^[MRg0VSQ=d!RRR=j<.=HWnM%IB)')MDC(FH(/HK&f9XQ(2]?jK]M\4],RfE&KP[#*jo2kh>SJ:V#>DX7U>/aJD490Wm0b!U0o>T?hF`Ois)7[g>Qr?Iu!81:NFE9>E>;%D5_%OP/@sZt3QX+Z\ZqhYdf_ql5_~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000526 00000 n 
+0000000594 00000 n 
+0000000890 00000 n 
+0000000949 00000 n 
+trailer
+<<
+/ID 
+[<e020f1bd89b4b05fd919c8ba283f7a83><e020f1bd89b4b05fd919c8ba283f7a83>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2461
+%%EOF


### PR DESCRIPTION
## Summary
- add an automation test overview PDF under codex automation test/version 01 describing the build run and blocked runtime validation steps

## Testing
- conan build . --output-folder=build --build=missing

------
https://chatgpt.com/codex/tasks/task_e_68d6893aa4b483338b2d9ad41bb3d37f