### PR TITLE
Add MIT license and community standards documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the Uber Backend project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces. Examples of representing our project include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at uber-backend-maintainers@example.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to the Uber Backend project! This document outlines a few guidelines to help you get started.
+
+## Code of Conduct
+
+All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it to understand how we work together to foster a welcoming and supportive community.
+
+## Getting Started
+
+1. **Fork the repository** and clone your fork locally.
+2. **Install dependencies** using the instructions in the project [README](README.md).
+3. **Create a feature branch** for your work: `git checkout -b feature/my-change`.
+4. **Keep changes focused**. Smaller, well-scoped pull requests are easier to review and merge.
+
+## Development Workflow
+
+1. Ensure your work includes tests or documentation where appropriate.
+2. Run the relevant test suites and linters before submitting your changes.
+3. Update any affected documentation, diagrams, or configuration files.
+4. Commit your changes with clear, descriptive messages.
+5. Push your branch and open a pull request describing the problem solved and the solution implemented.
+
+## Pull Request Checklist
+
+Before opening a pull request, please confirm that:
+
+- [ ] New or updated code includes appropriate tests.
+- [ ] All tests pass locally.
+- [ ] Documentation is updated to reflect the changes.
+- [ ] The pull request description clearly explains the change and any assumptions.
+
+## Reporting Issues
+
+If you find a bug or have a feature request, please open an issue. Include:
+
+- A clear description of the problem or proposed feature.
+- Steps to reproduce (for bugs).
+- Expected and actual behavior.
+- Any relevant logs, screenshots, or configuration details.
+
+## Release Process
+
+Release planning is coordinated by the maintainers. If you want to help with releases, please open a discussion with the project team first.
+
+## Questions?
+
+If you have questions, feel free to open a discussion or reach out to the maintainers by filing an issue tagged with `question`.
+
+We appreciate your contributions and look forward to building something great together!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Uber Backend Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -261,3 +261,12 @@ RABBITMQ_VHOST=/
 docker-compose up --build
 ```
 
+
+---
+
+## 🤝 Community & Project Standards
+
+- Review the [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participating in this community.
+- See the [Contributing Guide](CONTRIBUTING.md) for instructions on setting up your environment, coding standards, and submitting pull requests.
+- Consult the [Security Policy](SECURITY.md) for guidance on how to responsibly disclose vulnerabilities.
+- This project is distributed under the terms of the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates will be applied to the main branch of this repository. Please make sure you are running the latest commit from `main` to benefit from fixes.
+
+## Reporting a Vulnerability
+
+We take security issues seriously. If you discover a vulnerability in this project:
+
+1. **Do not create a public issue.** Instead, contact the maintainers privately at security@example.com.
+2. Provide as much detail as possible, including:
+   - Steps to reproduce the vulnerability
+   - The potential impact
+   - Any suggested mitigations
+3. Allow a reasonable amount of time for us to investigate and respond before disclosing the vulnerability publicly.
+
+## Preferred Languages
+
+Please submit reports in English when possible.
+
+## Responsible Disclosure
+
+We appreciate coordinated disclosure. We will work with you to understand the scope of the issue and will release patches and advisories as appropriate.


### PR DESCRIPTION
## Summary
- add an MIT License file to clarify the project's distribution terms
- document community expectations with a Contributor Covenant-based code of conduct and contributing guide
- publish a security policy and link the new governance docs from the README

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d68b36b6a08333bf2242f56cd34195