### PR TITLE
Implement ride settlement ledger and docker test stack

### DIFF
--- a/LocationManager/sql_scripts/database_init.sql
+++ b/LocationManager/sql_scripts/database_init.sql
@@ -57,7 +57,8 @@ CREATE TABLE IF NOT EXISTS payments (
     method ENUM('card', 'cash', 'wallet') NOT NULL,
     status ENUM('pending', 'completed', 'failed') DEFAULT 'pending',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (ride_id) REFERENCES rides(id) ON DELETE CASCADE
+    FOREIGN KEY (ride_id) REFERENCES rides(id) ON DELETE CASCADE,
+    UNIQUE KEY idx_payments_ride (ride_id)
 );
 
 -- Locations (saved places or live tracking)

--- a/LocationManager/src/main.cpp
+++ b/LocationManager/src/main.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
 
@@ -40,7 +38,7 @@ void stopApplication()
 int main()
 {
     startApplication();
-    std::cout << "Press Enter to stop server...\n";
+    logger_.logMeta(SingletonLogger::INFO, "Press Enter to stop server...", __FILE__, __LINE__, __func__);
     std::cin.get();
     stopApplication();
     return 0;

--- a/LocationManager/src/server.cpp
+++ b/LocationManager/src/server.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
 #include "../../sharedResources/include/sharedRabbitMQConsumer.h"
@@ -44,8 +43,14 @@ void Server::startConsumers()
     std::string topic = "user_created";
 
     std::shared_ptr<SharedKafkaConsumer> kafkaConsumer = sharedKafkaHandler_->createConsumer(name, topic);
-    kafkaConsumer->setCallback([](const std::string &msg)
-                               { std::cout << "[Kafka Msg] " << msg << std::endl; });
+    kafkaConsumer->setCallback([this](const std::string &msg)
+                               {
+                                   logger_.logMeta(SingletonLogger::INFO,
+                                                   std::string{"[Kafka][LocationManager] message -> "} + msg,
+                                                   __FILE__,
+                                                   __LINE__,
+                                                   __func__);
+                               });
 
     sharedKafkaHandler_->runConsumers();
 
@@ -64,8 +69,14 @@ void Server::startConsumers()
     auto rabbitConsumer = sharedRabbitHandler_->createConsumer("location_events", "location_updates");
     if (rabbitConsumer)
     {
-        rabbitConsumer->setCallback([](const std::string &message)
-                                    { std::cout << "[RabbitMQ] received payload: " << message << std::endl; });
+        rabbitConsumer->setCallback([this](const std::string &message)
+                                    {
+                                        logger_.logMeta(SingletonLogger::INFO,
+                                                        std::string{"[RabbitMQ][LocationManager] payload -> "} + message,
+                                                        __FILE__,
+                                                        __LINE__,
+                                                        __func__);
+                                    });
     }
 
     sharedRabbitHandler_->runConsumers();

--- a/RideManager/include/services/routeHandler/rideRouteHandler.h
+++ b/RideManager/include/services/routeHandler/rideRouteHandler.h
@@ -59,12 +59,19 @@ namespace UberBackend
             std::string statusReason;
             std::string requestedAt;
             std::string updatedAt;
+            double fareAmount{0.0};
+            std::string currency{"USD"};
+            bool fareRecorded{false};
+            std::string paymentMethod{"wallet"};
+            bool paymentRecorded{false};
         };
 
         struct DriverState
         {
             bool available{false};
             std::string currentRideId;
+            double walletBalance{0.0};
+            double lifetimeEarnings{0.0};
         };
 
         [[nodiscard]] std::string generateRideId();
@@ -82,6 +89,12 @@ namespace UberBackend
         [[nodiscard]] std::vector<RideRecord> findRidesByPredicate(const std::function<bool(const RideRecord &)> &predicate) const;
         [[nodiscard]] std::optional<nlohmann::json> fetchDriverProfile(const std::string &driverId) const;
         void persistRide(const RideRecord &record) const;
+        [[nodiscard]] std::optional<double> parseFareAmount(const nlohmann::json &payload) const;
+        void creditDriverWallet(const std::string &driverId, double amount, const RideRecord &record);
+        [[nodiscard]] double getDriverWalletBalance(const std::string &driverId) const;
+        bool recordPaymentInDatabase(const RideRecord &record, double amount, const std::string &method);
+        [[nodiscard]] std::optional<long long> lookupRidePrimaryKey(const std::string &rideIdentifier) const;
+        [[nodiscard]] DriverState snapshotDriverState(const std::string &driverId) const;
 
         utils::SingletonLogger &logger_;
         std::unique_ptr<RideKafkaManager> kafkaManager_;

--- a/RideManager/sql_scripts/database_init.sql
+++ b/RideManager/sql_scripts/database_init.sql
@@ -66,7 +66,8 @@ CREATE TABLE IF NOT EXISTS payments (
     method ENUM('card', 'cash', 'wallet') NOT NULL,
     status ENUM('pending', 'completed', 'failed') DEFAULT 'pending',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (ride_id) REFERENCES rides(id) ON DELETE CASCADE
+    FOREIGN KEY (ride_id) REFERENCES rides(id) ON DELETE CASCADE,
+    UNIQUE KEY idx_payments_ride (ride_id)
 );
 
 -- Locations (optional live tracking or saved places)

--- a/RideManager/src/main.cpp
+++ b/RideManager/src/main.cpp
@@ -1,5 +1,4 @@
 #include <filesystem>
-#include <iostream>
 
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
@@ -51,7 +50,7 @@ namespace
 int main()
 {
     startApplication();
-    std::cout << "RideManager service running. Press Enter to exit..." << std::endl;
+    logger.logMeta(SingletonLogger::INFO, "RideManager service running. Press Enter to exit...", __FILE__, __LINE__, __func__);
     std::cin.get();
     stopApplication();
     return 0;

--- a/RideManager/src/server.cpp
+++ b/RideManager/src/server.cpp
@@ -1,7 +1,5 @@
 #include "../include/server.h"
 
-#include <iostream>
-
 #include "../../sharedResources/include/sharedKafkaHandler.h"
 #include "../../sharedResources/include/sharedRabbitMQConsumer.h"
 #include "../../sharedResources/include/sharedRabbitMQHandler.h"
@@ -53,18 +51,26 @@ namespace UberBackend
         auto rideLifecycleConsumer = sharedKafkaHandler_->createConsumer("ride_manager_lifecycle", "ride_lifecycle_events");
         if (rideLifecycleConsumer)
         {
-            rideLifecycleConsumer->setCallback([](const std::string &payload)
+            rideLifecycleConsumer->setCallback([this](const std::string &payload)
                                                {
-                                                   std::cout << "[Kafka][RideManager] lifecycle event -> " << payload << std::endl;
+                                                   logger_.logMeta(SingletonLogger::INFO,
+                                                                   std::string{"[Kafka][RideManager] lifecycle event -> "} + payload,
+                                                                   __FILE__,
+                                                                   __LINE__,
+                                                                   __func__);
                                                });
         }
 
         auto locationBridgeConsumer = sharedKafkaHandler_->createConsumer("ride_manager_location_bridge", "location_events");
         if (locationBridgeConsumer)
         {
-            locationBridgeConsumer->setCallback([](const std::string &payload)
+            locationBridgeConsumer->setCallback([this](const std::string &payload)
                                                 {
-                                                    std::cout << "[Kafka][RideManager] location update -> " << payload << std::endl;
+                                                    logger_.logMeta(SingletonLogger::INFO,
+                                                                    std::string{"[Kafka][RideManager] location update -> "} + payload,
+                                                                    __FILE__,
+                                                                    __LINE__,
+                                                                    __func__);
                                                 });
         }
 
@@ -93,9 +99,13 @@ namespace UberBackend
         auto driverTaskConsumer = sharedRabbitHandler_->createConsumer("ride_manager_driver_tasks", "driver_notifications");
         if (driverTaskConsumer)
         {
-            driverTaskConsumer->setCallback([](const std::string &message)
+            driverTaskConsumer->setCallback([this](const std::string &message)
                                             {
-                                                std::cout << "[RabbitMQ][RideManager] driver task -> " << message << std::endl;
+                                                logger_.logMeta(SingletonLogger::INFO,
+                                                                std::string{"[RabbitMQ][RideManager] driver task -> "} + message,
+                                                                __FILE__,
+                                                                __LINE__,
+                                                                __func__);
                                             });
         }
 

--- a/UserManager/src/main.cpp
+++ b/UserManager/src/main.cpp
@@ -1,5 +1,4 @@
 #include <filesystem>
-#include <iostream>
 
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
@@ -65,7 +64,7 @@ int main()
 {
     startApplication();
     // Wait for user input to stop the server just for debugging purposes
-    std::cout << "Press Enter to stop server...\n";
+    logger_.logMeta(SingletonLogger::INFO, "Press Enter to stop server...", __FILE__, __LINE__, __func__);
     std::cin.get();
     stopApplication();
     return 0;

--- a/UserManager/src/server.cpp
+++ b/UserManager/src/server.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "../include/server.h"
 #include "../../sharedUtils/include/config.h"
 #include "../../sharedResources/include/sharedRabbitMQConsumer.h"
@@ -39,8 +37,14 @@ void Server::startConsumers()
     auto kafkaConsumer = sharedKafkaHandler_->createConsumer("user_manager_profile_events", "user_profile_updated");
     if (kafkaConsumer)
     {
-        kafkaConsumer->setCallback([](const std::string &payload)
-                                   { std::cout << "[Kafka][UserManager] profile update event -> " << payload << std::endl; });
+        kafkaConsumer->setCallback([this](const std::string &payload)
+                                   {
+                                       logger_.logMeta(SingletonLogger::INFO,
+                                                       std::string{"[Kafka][UserManager] profile update event -> "} + payload,
+                                                       __FILE__,
+                                                       __LINE__,
+                                                       __func__);
+                                   });
     }
 
     sharedKafkaHandler_->runConsumers();
@@ -60,8 +64,14 @@ void Server::startConsumers()
     auto taskConsumer = sharedRabbitHandler_->createConsumer("user_manager_tasks", "user_tasks");
     if (taskConsumer)
     {
-        taskConsumer->setCallback([](const std::string &task)
-                                  { std::cout << "[RabbitMQ][UserManager] task received -> " << task << std::endl; });
+        taskConsumer->setCallback([this](const std::string &task)
+                                  {
+                                      logger_.logMeta(SingletonLogger::INFO,
+                                                      std::string{"[RabbitMQ][UserManager] task received -> "} + task,
+                                                      __FILE__,
+                                                      __LINE__,
+                                                      __func__);
+                                  });
     }
 
     sharedRabbitHandler_->runConsumers();

--- a/docker/Dockerfile.LocationManager
+++ b/docker/Dockerfile.LocationManager
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM pasanaa/uber-base:latest
+FROM uber_base:latest
 
 # Set working directory
 WORKDIR /UberBackend

--- a/docker/Dockerfile.RideManager
+++ b/docker/Dockerfile.RideManager
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM pasanaa/uber-base:latest
+FROM uber_base:latest
 
 # Set working directory
 WORKDIR /UberBackend

--- a/docker/Dockerfile.UserManager
+++ b/docker/Dockerfile.UserManager
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM pasanaa/uber-base:latest
+FROM uber_base:latest
 
 # Set working directory
 WORKDIR /UberBackend

--- a/docker/docker-compose.test-deploy.yml
+++ b/docker/docker-compose.test-deploy.yml
@@ -1,0 +1,147 @@
+version: "3.9"
+
+services:
+  kafka:
+    image: bitnami/kafka:3.6.0
+    container_name: kafka-bus
+    environment:
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka-bus:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-bus:9092
+      - KAFKA_CFG_LOG_DIRS=/bitnami/kafka/data
+      - KAFKA_HEAP_OPTS=-Xmx512m -Xms512m
+    ports:
+      - "${KAFKA_EXTERNAL_PORT:-9092}:9092"
+    volumes:
+      - kafka_data:/bitnami/kafka/data
+    networks:
+      - backend
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq-bus
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-guest}
+      RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_VHOST:-/}
+    ports:
+      - "${RABBITMQ_HTTP_PORT:-15672}:15672"
+      - "${RABBITMQ_AMQP_PORT:-5672}:5672"
+    networks:
+      - backend
+
+  redis:
+    image: redis:7
+    container_name: redis-cache
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - backend
+
+  mysql_user:
+    image: mysql:8
+    container_name: mysql-usermanager
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${USERMANAGER_DB:-userManagerDatabase}
+      MYSQL_USER: ${MYSQL_USER:-uber}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
+    volumes:
+      - mysql_user_data:/var/lib/mysql
+    ports:
+      - "${USERMANAGER_PORT:-3307}:3306"
+    networks:
+      - backend
+
+  mysql_ride:
+    image: mysql:8
+    container_name: mysql-ridemanager
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${RIDEMANAGER_DB:-uber_database}
+      MYSQL_USER: ${MYSQL_USER:-uber}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
+    volumes:
+      - mysql_ride_data:/var/lib/mysql
+    ports:
+      - "${RIDEMANAGER_PORT:-3308}:3306"
+    networks:
+      - backend
+
+  mysql_location:
+    image: mysql:8
+    container_name: mysql-locationmanager
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${LOCATIONMANAGER_DB:-location_database}
+      MYSQL_USER: ${MYSQL_USER:-uber}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
+    volumes:
+      - mysql_location_data:/var/lib/mysql
+    ports:
+      - "${LOCATIONMANAGER_PORT:-3309}:3306"
+    networks:
+      - backend
+
+  usermanager:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.UserManager
+    image: uber_usermanager:test
+    depends_on:
+      - mysql_user
+      - kafka
+      - rabbitmq
+    environment:
+      - SERVICE_ROLE=usermanager
+    ports:
+      - "${USERMANAGER_APP_PORT:-8081}:8081"
+    networks:
+      - backend
+
+  ridemanager:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.RideManager
+    image: uber_ridemanager:test
+    depends_on:
+      - mysql_ride
+      - kafka
+      - rabbitmq
+    environment:
+      - SERVICE_ROLE=ridemanager
+    ports:
+      - "${RIDEMANAGER_APP_PORT:-8082}:8081"
+    networks:
+      - backend
+
+  locationmanager:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.LocationManager
+    image: uber_locationmanager:test
+    depends_on:
+      - mysql_location
+      - kafka
+      - rabbitmq
+    environment:
+      - SERVICE_ROLE=locationmanager
+    ports:
+      - "${LOCATIONMANAGER_APP_PORT:-8083}:8081"
+    networks:
+      - backend
+
+networks:
+  backend:
+    driver: bridge
+
+volumes:
+  kafka_data:
+  mysql_user_data:
+  mysql_ride_data:
+  mysql_location_data:

--- a/docker/dockerCMD.txt
+++ b/docker/dockerCMD.txt
@@ -1,9 +1,7 @@
 docker build -f docker/Dockerfile.base -t uber_base:latest .
 
-docker build -f docker/Dockerfile.UserManager -t usermanager:latest .
+docker compose -f docker/docker-compose.test-deploy.yml --env-file .env build
 
-docker build -f docker/Dockerfile.RideManager -t ridemanager:latest .
+docker compose -f docker/docker-compose.test-deploy.yml --env-file .env up -d
 
-docker build -f docker/Dockerfile.LocationManager -t locationmanager:latest .
-
-docker compose --env-file .env up -d
+docker compose -f docker/docker-compose.test-deploy.yml down

--- a/docs/ride_lifecycle_settlement.md
+++ b/docs/ride_lifecycle_settlement.md
@@ -1,0 +1,35 @@
+# Ride Booking to Driver Wallet Settlement – Execution Report
+
+This report explains the full back-end flow from the moment a rider requests a trip until the driver receives the fare in their in-app wallet. Each step references the C++ services and database mutations that guarantee atomic ride lifecycle processing.
+
+## 1. Rider submits a ride request
+
+1. The `RideManager` HTTP layer validates the incoming JSON body (`rider_id`, pickup/dropoff details) and enriches it with optional `currency` and `payment_method` hints from the client.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L451-L521】
+2. The service matches an available driver from cached availability (including a proximity query via the `LocationGateway`).【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L472-L505】
+3. A new in-memory `RideRecord` is created, persisted to MySQL (including fare placeholders) via `persistRide`, and broadcast to Kafka (`ride.requested`, `ride.assigned`) and RabbitMQ for downstream dispatchers.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L507-L537】【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L205-L261】
+4. The shared `SingletonLogger` records every major action, ensuring observability without any `std::cout` statements across the project.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L323-L343】【F:RideManager/src/server.cpp†L38-L115】
+
+## 2. Driver acknowledges and progresses the ride
+
+1. Drivers (or automation) report their availability through `/drivers/{id}/status`. The handler snapshots the driver ledger and publishes Kafka events containing wallet balances for real-time dashboards.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L640-L664】
+2. Status transitions (`accepted`, `in_progress`) update the ride record and persist the mutation, keeping database state and in-memory cache synchronized.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L558-L628】
+
+## 3. Ride completion and fare settlement
+
+1. When `/rides/{id}/status` is called with `status: completed` and a `fare`, the handler normalizes the fare value, stores it in the ride record, and marks the driver available again.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L569-L610】
+2. `creditDriverWallet` increments both the driver’s current wallet balance and lifetime earnings under a thread-safe lock, logging the credit with the singleton logger for audit trails.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L323-L343】
+3. `recordPaymentInDatabase` resolves the ride’s primary key, upserts the `payments` table with a completed `wallet` settlement, and reports success/failure through structured logs.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L352-L399】【F:RideManager/sql_scripts/database_init.sql†L34-L42】
+4. The updated ride payload published to Kafka/RabbitMQ now carries a `payment` section (method + status) so consumers can verify the settlement asynchronously.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L99-L122】【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L630-L635】
+
+## 4. Post-ride introspection and driver payouts
+
+1. `handleGetDriverProfile` federates the profile data from `UserManager` and appends the latest wallet snapshot (balance and lifetime earnings), exposing the same ledger numbers that were updated during settlement.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L705-L718】
+2. Operators can query `/drivers/{id}/status` to retrieve availability together with wallet totals, thanks to the enriched `driverState` payload described earlier.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L640-L664】
+3. Every REST response and event stream originates from `rideToJson`, guaranteeing that downstream systems see the same fare and payment metadata that the wallet ledger used for settlement.【F:RideManager/src/services/routeHandler/rideRouteHandler.cpp†L99-L138】
+
+## 5. Infrastructure required for test deployments
+
+1. Build the shared toolchain image once (`Dockerfile.base`) and then spin up the dedicated Docker Compose stack that stands up Kafka, RabbitMQ, Redis, three MySQL instances, and all microservices from source.【F:docker/dockerCMD.txt†L1-L8】【F:docker/docker-compose.test-deploy.yml†L1-L126】
+2. Each service container runs `conan build . --output-folder=build --build=missing -s build_type=Release` before launching, ensuring parity with local builds and exercising the wallet settlement flow under production-like conditions.【F:entrypointRideManager.sh†L1-L6】【F:entrypointUserManager.sh†L1-L6】【F:entrypointLocationManager.sh†L1-L6】
+
+With these components working in concert, the rider’s fare is deterministically routed from request validation through driver payout without manual intervention, and all observability tooling consumes a consistent payment record.

--- a/entrypointLocationManager.sh
+++ b/entrypointLocationManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-conan build . --build=missing -s build_type=Release
+conan build . --output-folder=build --build=missing -s build_type=Release
 
 ./build/Release/bin/LocationManager

--- a/entrypointRideManager.sh
+++ b/entrypointRideManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-conan build . --build=missing -s build_type=Release
+conan build . --output-folder=build --build=missing -s build_type=Release
 
 ./build/Release/bin/RideManager

--- a/entrypointUserManager.sh
+++ b/entrypointUserManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-conan build . --build=missing -s build_type=Release
+conan build . --output-folder=build --build=missing -s build_type=Release
 
 ./build/Release/bin/UserManager


### PR DESCRIPTION
## Summary
- extend the ride lifecycle to capture fares, credit driver wallets, and persist payment records while documenting the flow in `docs/ride_lifecycle_settlement.md`
- replace ad-hoc std::cout logging across services with the shared SingletonLogger and update entrypoints to the new Conan build invocation
- provide a docker-compose test deployment stack that builds from local sources and refresh the README/docker guidance

## Testing
- ~/.local/bin/conan build . --output-folder=build --build=missing

------
https://chatgpt.com/codex/tasks/task_e_68d71f5a7718833381fd3bc83bad7313