### PR TITLE
Repair workflow scripts to eliminate YAML parsing failures

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -43,10 +43,21 @@ jobs:
           HAS_DOCKERHUB_CREDS: ${{ env.HAS_DOCKERHUB_CREDS }}
         run: |
           set -euo pipefail
-          while read -r dockerfile image_name; do
+
+          images=(
+            "docker/Dockerfile.base uber-base"
+            "docker/Dockerfile.UserManager usermanager"
+            "docker/Dockerfile.RideManager ridemanager"
+            "docker/Dockerfile.LocationManager locationmanager"
+          )
+
+          for entry in "${images[@]}"; do
+            IFS=' ' read -r dockerfile image_name <<< "${entry}"
+
             local_tag="${image_name}:ci"
             echo "Building ${dockerfile} as ${local_tag}"
             docker build -f "${dockerfile}" -t "${local_tag}" .
+
             if [ "${HAS_DOCKERHUB_CREDS}" = "true" ]; then
               remote_tag="${DOCKERHUB_USERNAME}/${image_name}:latest"
               echo "Pushing ${remote_tag}"
@@ -55,9 +66,4 @@ jobs:
             else
               echo "Skipping push for ${image_name}; DockerHub credentials not available."
             fi
-          done <<'EOF'
-docker/Dockerfile.base uber-base
-docker/Dockerfile.UserManager usermanager
-docker/Dockerfile.RideManager ridemanager
-docker/Dockerfile.LocationManager locationmanager
-EOF
+          done

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -66,32 +66,25 @@ jobs:
 
       - name: ✅ Wait for UserManager health endpoint
         run: |
-          python3 - <<'PY'
-import json
-import sys
-import time
-import urllib.error
-import urllib.request
+          set -euo pipefail
+          deadline=$((SECONDS + 420))
 
-url = "http://localhost:8081/health"
-deadline = time.time() + 420
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            if response=$(curl --silent --show-error --fail --connect-timeout 5 http://localhost:8081/health 2>/dev/null); then
+              if python3 -c "import json,sys; data=json.load(sys.stdin); sys.exit(0 if data.get('database', {}).get('healthy') else 1)" <<<"${response}"; then
+                echo "UserManager health check passed."
+                exit 0
+              fi
+              echo "Health endpoint reachable but database not yet healthy." >&2
+            else
+              echo "Waiting for health endpoint..." >&2
+            fi
 
-while time.time() < deadline:
-    try:
-        with urllib.request.urlopen(url, timeout=5) as response:
-            payload = json.load(response)
-        if payload.get("database", {}).get("healthy"):
-            print("UserManager health check passed.")
-            sys.exit(0)
-        print("Health endpoint reachable but database not yet healthy.", file=sys.stderr)
-    except Exception as exc:  # noqa: BLE001
-        print(f"Waiting for health endpoint: {exc}", file=sys.stderr)
+            sleep 5
+          done
 
-    time.sleep(5)
-
-print("Timed out waiting for UserManager health endpoint to become healthy.", file=sys.stderr)
-sys.exit(1)
-PY
+          echo "Timed out waiting for UserManager health endpoint to become healthy." >&2
+          exit 1
 
       - name: ✅ Test - All containers are running
         run: |

--- a/.github/workflows/docker-test-deploy.yml
+++ b/.github/workflows/docker-test-deploy.yml
@@ -56,32 +56,25 @@ jobs:
 
       - name: ✅ Wait for UserManager health endpoint
         run: |
-          python3 - <<'PY'
-import json
-import sys
-import time
-import urllib.error
-import urllib.request
+          set -euo pipefail
+          deadline=$((SECONDS + 420))
 
-url = "http://localhost:8081/health"
-deadline = time.time() + 420
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            if response=$(curl --silent --show-error --fail --connect-timeout 5 http://localhost:8081/health 2>/dev/null); then
+              if python3 -c "import json,sys; data=json.load(sys.stdin); sys.exit(0 if data.get('database', {}).get('healthy') else 1)" <<<"${response}"; then
+                echo "UserManager health check passed."
+                exit 0
+              fi
+              echo "Health endpoint reachable but database not yet healthy." >&2
+            else
+              echo "Waiting for health endpoint..." >&2
+            fi
 
-while time.time() < deadline:
-    try:
-        with urllib.request.urlopen(url, timeout=5) as response:
-            payload = json.load(response)
-        if payload.get("database", {}).get("healthy"):
-            print("UserManager health check passed.")
-            sys.exit(0)
-        print("Health endpoint reachable but database not yet healthy.", file=sys.stderr)
-    except Exception as exc:  # noqa: BLE001
-        print(f"Waiting for health endpoint: {exc}", file=sys.stderr)
+            sleep 5
+          done
 
-    time.sleep(5)
-
-print("Timed out waiting for UserManager health endpoint to become healthy.", file=sys.stderr)
-sys.exit(1)
-PY
+          echo "Timed out waiting for UserManager health endpoint to become healthy." >&2
+          exit 1
 
       - name: ✅ Verify application containers
         run: |


### PR DESCRIPTION
## Summary
- replace the Docker image build heredoc in the CI workflow with an explicit Bash array loop so the shell no longer sees an indented terminator
- rework the health check steps in the docker-compose and test-deploy workflows to use a shell polling loop and inline Python command, avoiding invalid YAML generated by heredoc blocks

## Testing
- yamllint .github/workflows/docker-ci.yml .github/workflows/docker-compose.yml .github/workflows/docker-test-deploy.yml *(line-length warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68d73938a6b883339fe808d09a14f7e4