### PR TITLE
Align logger with cpp_base utilities

### DIFF
--- a/sharedUtils/CMakeLists.txt
+++ b/sharedUtils/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(uber_shared_utils
     src/jwt.cpp
     src/utils.cpp
     src/algorithms_sha256.cpp
+    src/time.cpp
 )
 
 target_include_directories(uber_shared_utils

--- a/sharedUtils/include/utils/index.h
+++ b/sharedUtils/include/utils/index.h
@@ -1,15 +1,11 @@
 #pragma once
 
-#include <chrono>
 #include <condition_variable>
 #include <functional>
-#include <iomanip>
-#include <iostream>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <sstream>
-#include <future>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -28,8 +24,9 @@ public:
         ERROR
     };
 
-    static SingletonLogger &instance();
+    static SingletonLogger &instance(const std::string &logFilePath = "log/log.txt");
 
+    void log(Level level, const std::string &message);
     void logMeta(Level level,
                  const std::string &message,
                  const char *file,
@@ -37,12 +34,14 @@ public:
                  const char *function);
 
 private:
-    SingletonLogger() = default;
-    ~SingletonLogger() = default;
+    explicit SingletonLogger(const std::string &logFilePath);
+    ~SingletonLogger();
 
-    std::string levelToString(Level level) const;
+    void printLog(const std::string &message);
+    void printConsole(Level level, const std::string &message);
 
-    std::mutex mutex_;
+    static std::mutex logMutex_;
+    std::string logFilePath_;
 };
 
 class ThreadPool {

--- a/sharedUtils/include/utils/time.h
+++ b/sharedUtils/include/utils/time.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+namespace utils {
+
+class Time {
+private:
+    static std::string validTime(int value);
+
+public:
+    static std::uint64_t getEpocTimeInNanoseconds();
+    static std::uint64_t getEpocTimeInMicroseconds();
+    static std::uint64_t getEpocTimeInMilliseconds();
+    static std::uint64_t getEpocTimeInSeconds();
+    static std::uint64_t getEpocTimeInMinutes();
+    static void printNowTime();
+    static void holdSeconds(int seconds);
+    static void holdMiliseconds(int milliseconds);
+    static std::string logTime();
+};
+
+} // namespace utils
+

--- a/sharedUtils/src/time.cpp
+++ b/sharedUtils/src/time.cpp
@@ -1,0 +1,120 @@
+#include "../include/utils/time.h"
+
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+namespace utils {
+
+std::uint64_t Time::getEpocTimeInNanoseconds()
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::uint64_t Time::getEpocTimeInMicroseconds()
+{
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::uint64_t Time::getEpocTimeInMilliseconds()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::uint64_t Time::getEpocTimeInSeconds()
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::uint64_t Time::getEpocTimeInMinutes()
+{
+    return std::chrono::duration_cast<std::chrono::minutes>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+void Time::printNowTime()
+{
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
+
+    std::tm tmSnapshot{};
+#if defined(_WIN32)
+    localtime_s(&tmSnapshot, &timeValue);
+#else
+    localtime_r(&timeValue, &tmSnapshot);
+#endif
+
+    std::cout << std::put_time(&tmSnapshot, "%Y-%m-%d %H:%M:%S") << std::endl;
+}
+
+void Time::holdSeconds(int seconds)
+{
+    if (seconds <= 0)
+    {
+        return;
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(seconds));
+}
+
+void Time::holdMiliseconds(int milliseconds)
+{
+    if (milliseconds <= 0)
+    {
+        return;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+}
+
+std::string Time::validTime(int value)
+{
+    if (value < 0)
+    {
+        value = 0;
+    }
+
+    std::ostringstream stream;
+    stream << std::setfill('0') << std::setw(3) << value;
+    return stream.str();
+}
+
+std::string Time::logTime()
+{
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
+
+    std::tm tmSnapshot{};
+#if defined(_WIN32)
+    localtime_s(&tmSnapshot, &timeValue);
+#else
+    localtime_r(&timeValue, &tmSnapshot);
+#endif
+
+    std::ostringstream logStream;
+    logStream << std::put_time(&tmSnapshot, "%Y-%m-%d %T");
+
+    const auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
+    const auto nanosCount = nanos.count();
+    const int milli = static_cast<int>((nanosCount / 1'000'000) % 1000);
+    const int micro = static_cast<int>((nanosCount / 1'000) % 1000);
+    const int nano = static_cast<int>(nanosCount % 1000);
+
+    std::ostringstream result;
+    result << '[' << logStream.str() << ':' << validTime(milli) << ':' << validTime(micro) << ':' << validTime(nano) << ']';
+    return result.str();
+}
+
+} // namespace utils
+

--- a/sharedUtils/src/utils.cpp
+++ b/sharedUtils/src/utils.cpp
@@ -1,34 +1,89 @@
 #include "../include/utils/index.h"
 
+#include <cstdio>
+#include <fcntl.h>
+#include <filesystem>
+#include <system_error>
+#include <iostream>
+#include <sstream>
+#include <sys/file.h>
+#include <unistd.h>
+
+#include "../include/utils/time.h"
+
 namespace utils {
 
 namespace {
-constexpr const char *levelToColor(SingletonLogger::Level level)
+std::string levelToString(SingletonLogger::Level level)
 {
     switch (level)
     {
     case SingletonLogger::DEBUG:
-        return "\033[36m"; // Cyan
+        return "DEBUG";
     case SingletonLogger::INFO:
-        return "\033[32m"; // Green
+        return "INFO";
     case SingletonLogger::WARNING:
-        return "\033[33m"; // Yellow
+        return "WARNING";
     case SingletonLogger::ERROR:
     default:
-        return "\033[31m"; // Red
+        return "ERROR";
     }
-}
-
-constexpr const char *resetColor()
-{
-    return "\033[0m";
 }
 } // namespace
 
-SingletonLogger &SingletonLogger::instance()
+std::mutex SingletonLogger::logMutex_;
+
+SingletonLogger &SingletonLogger::instance(const std::string &logFilePath)
 {
-    static SingletonLogger logger;
+    static SingletonLogger logger(logFilePath);
     return logger;
+}
+
+SingletonLogger::SingletonLogger(const std::string &logFilePath)
+    : logFilePath_(logFilePath)
+{
+    namespace fs = std::filesystem;
+
+    fs::path logPath(logFilePath_);
+
+    std::error_code ec;
+    const bool exists = fs::exists(logPath, ec);
+    if (ec)
+    {
+        std::cerr << "SingletonLogger: failed to inspect existing log file at '" << logFilePath_
+                  << "': " << ec.message() << std::endl;
+        ec.clear();
+    }
+
+    if (exists)
+    {
+        fs::remove(logPath, ec);
+        if (ec)
+        {
+            std::cerr << "SingletonLogger: failed to remove existing log file at '" << logFilePath_
+                      << "': " << ec.message() << std::endl;
+            ec.clear();
+        }
+    }
+
+    if (logPath.has_parent_path())
+    {
+        fs::create_directories(logPath.parent_path(), ec);
+        if (ec)
+        {
+            std::cerr << "SingletonLogger: failed to create log directory '" << logPath.parent_path().string()
+                      << "': " << ec.message() << std::endl;
+        }
+    }
+}
+
+SingletonLogger::~SingletonLogger() = default;
+
+void SingletonLogger::log(Level level, const std::string &message)
+{
+    const std::string formatted = Time::logTime() + " [ " + levelToString(level) + " ] " + message;
+    printLog(formatted);
+    printConsole(level, formatted);
 }
 
 void SingletonLogger::logMeta(Level level,
@@ -37,25 +92,70 @@ void SingletonLogger::logMeta(Level level,
                               int line,
                               const char *function)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    std::ostringstream oss;
-    oss << '[' << levelToString(level) << "] " << file << ':' << line << " (" << function << ") - " << message;
-    std::cout << levelToColor(level) << oss.str() << resetColor() << std::endl;
+    std::ostringstream metadata;
+    metadata << file << ':' << line << " in " << function;
+
+    const std::string formatted = Time::logTime() + " [ " + levelToString(level) + " ] " + message + " | " + metadata.str();
+    printLog(formatted);
+    printConsole(level, formatted);
 }
 
-std::string SingletonLogger::levelToString(Level level) const
+void SingletonLogger::printLog(const std::string &message)
 {
+    std::lock_guard<std::mutex> lock(logMutex_);
+
+    int fd = open(logFilePath_.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+    if (fd == -1)
+    {
+        std::perror("SingletonLogger open");
+        return;
+    }
+
+    if (flock(fd, LOCK_EX) == -1)
+    {
+        std::perror("SingletonLogger flock");
+        close(fd);
+        return;
+    }
+
+    const std::string line = message + '\n';
+    if (write(fd, line.c_str(), line.size()) == -1)
+    {
+        std::perror("SingletonLogger write");
+    }
+
+    flock(fd, LOCK_UN);
+    close(fd);
+}
+
+void SingletonLogger::printConsole(Level level, const std::string &message)
+{
+#ifdef DEBUG_MODE
+    constexpr bool debugEnabled = true;
+#else
+    constexpr bool debugEnabled = false;
+#endif
+
     switch (level)
     {
-    case DEBUG:
-        return "DEBUG";
-    case INFO:
-        return "INFO";
-    case WARNING:
-        return "WARNING";
-    case ERROR:
+    case Level::ERROR:
+        std::cout << "\033[1;31m[ERROR] " << message << "\033[0m" << std::endl;
+        break;
+    case Level::WARNING:
+        std::cout << "\033[1;33m[WARNING] " << message << "\033[0m" << std::endl;
+        break;
+    case Level::INFO:
+        std::cout << "[INFO] " << message << std::endl;
+        break;
+    case Level::DEBUG:
+        if (debugEnabled)
+        {
+            std::cout << "\033[1;36m[DEBUG] " << message << "\033[0m" << std::endl;
+        }
+        break;
     default:
-        return "ERROR";
+        std::cout << message << std::endl;
+        break;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the ad-hoc singleton logger implementation with the cpp_base version, adding explicit log() support and cpp_base-style formatting
- add the shared Time utility to provide high-resolution timestamps and wire it into the logger while updating the build to compile it

## Testing
- cmake -S . -B build
- cmake --build build --target sharedUtils
- g++ -std=c++17 -I. -pthread sharedUtils/src/utils.cpp sharedUtils/src/time.cpp /tmp/test_logger.cpp -o /tmp/test_logger
- /tmp/test_logger
- cat /tmp/uber_backend_test.log

------
https://chatgpt.com/codex/tasks/task_e_68d74b0100a88333a71f36b179444c50