### PR TITLE
Fix YAML indentation for gRPC workflow step

### DIFF
--- a/.github/workflows/unified-system.yml
+++ b/.github/workflows/unified-system.yml
@@ -281,7 +281,7 @@ jobs:
           timeout 600 bash -c "until nc -z localhost 50051; do sleep 5; done"
 
       - name: ✅ Execute gRPC connectivity test
-        run: |
+        run: |2
           set -euo pipefail
           report_dir="reports"
           mkdir -p "${report_dir}"
@@ -291,16 +291,16 @@ jobs:
           echo >> "${report_file}"
 
           python3 - <<'PY' > grpc-test.log
-import grpc
-import sys
-try:
-    channel = grpc.insecure_channel("localhost:50051")
-    grpc.channel_ready_future(channel).result(timeout=60)
-    print("gRPC channel to localhost:50051 is ready.")
-except Exception as exc:
-    print(f"Failed to establish gRPC channel: {exc}", file=sys.stderr)
-    sys.exit(1)
-PY
+  import grpc
+  import sys
+  try:
+      channel = grpc.insecure_channel("localhost:50051")
+      grpc.channel_ready_future(channel).result(timeout=60)
+      print("gRPC channel to localhost:50051 is ready.")
+  except Exception as exc:
+      print(f"Failed to establish gRPC channel: {exc}", file=sys.stderr)
+      sys.exit(1)
+  PY
 
           cat grpc-test.log >> "${report_file}"
 


### PR DESCRIPTION
## Summary
- ensure the gRPC connectivity step uses a literal block with explicit indentation so GitHub Actions can parse it
- indent the embedded Python script to keep the heredoc valid within the workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d75f58d550833399feec763db39a2e