### PR TITLE
Ensure nlohmann_json is available during builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,17 @@ endif()
 
 set(CCP_BASE_SOURCE_DIR "${cpp_base_SOURCE_DIR}" CACHE PATH "cpp-base source directory")
 
+# nlohmann_json is consumed as an imported target inside sharedUtils. The
+# project previously expected the dependency to be provided by the host
+# toolchain, which is not true in CI. Fetching it ensures consistent builds
+# everywhere without requiring a pre-installed package.
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 # Output directories for all targets
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/LocationManager/CMakeLists.txt
+++ b/LocationManager/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json CONFIG REQUIRED)
+endif()
 
 # --- Source Files ---
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)

--- a/RideManager/CMakeLists.txt
+++ b/RideManager/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(RideManager)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json CONFIG REQUIRED)
+endif()
 
 # Collect source files
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)

--- a/UserManager/CMakeLists.txt
+++ b/UserManager/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json CONFIG REQUIRED)
+endif()
 
 # --- Source Files ---
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS src/*.cpp)

--- a/sharedResources/CMakeLists.txt
+++ b/sharedResources/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.25.2)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json CONFIG REQUIRED)
+endif()
 
 add_library(uber_shared_resources
     src/sharedDatabase.cpp

--- a/sharedUtils/CMakeLists.txt
+++ b/sharedUtils/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.25.2)
 
-find_package(nlohmann_json CONFIG REQUIRED)
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json CONFIG REQUIRED)
+endif()
 
 if(NOT CCP_BASE_SOURCE_DIR)
     message(FATAL_ERROR "CCP_BASE_SOURCE_DIR is not defined. Did you forget to populate cpp-base?")


### PR DESCRIPTION
## Summary
- fetch nlohmann_json with FetchContent so the header-only dependency is always present
- guard service CMake files so they only call find_package when the target is not already provided

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d7610c7cd88333b373aa9a6349b290