### PR TITLE
Fix service entrypoints to use default Conan layout

### DIFF
--- a/entrypointLocationManager.sh
+++ b/entrypointLocationManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-conan build . --output-folder=build --build=missing -s build_type=Release
+conan build . --build=missing -s build_type=Release
 
 ./build/Release/bin/LocationManager

--- a/entrypointRideManager.sh
+++ b/entrypointRideManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-conan build . --output-folder=build --build=missing -s build_type=Release
+conan build . --build=missing -s build_type=Release
 
 ./build/Release/bin/RideManager

--- a/entrypointUserManager.sh
+++ b/entrypointUserManager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-conan build . --output-folder=build --build=missing -s build_type=Release
+conan build . --build=missing -s build_type=Release
 
 ./build/Release/bin/UserManager


### PR DESCRIPTION
## Summary
- update each service entrypoint to rely on Conan's default build directory so the compiled binaries are placed under build/Release/bin

## Testing
- conan build . --build=missing -s build_type=Release

------
https://chatgpt.com/codex/tasks/task_e_68d86980df708333b652fa0c01ac9341