### PR TITLE
Add root service status endpoints

### DIFF
--- a/LocationManager/src/services/httpHandler/servers/httpLocationServer.cpp
+++ b/LocationManager/src/services/httpHandler/servers/httpLocationServer.cpp
@@ -20,6 +20,15 @@ HttpLocationServer::HttpLocationServer(const std::string &name,
 
 void HttpLocationServer::createServerMethods()
 {
+    server_->Get("/", [](const httplib::Request &, httplib::Response &res)
+    {
+        res.status = 200;
+        res.set_content(nlohmann::json{{"status", "ok"},
+                                        {"service", "LocationManager"},
+                                        {"message", "Location Manager HTTP interface is running"}}.dump(),
+                        "application/json");
+    });
+
     server_->Post("/location/update", [this](const httplib::Request &req, httplib::Response &res) {
         json payload;
         try

--- a/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
+++ b/RideManager/src/services/httpHandler/servers/httpRideServer.cpp
@@ -44,6 +44,14 @@ namespace UberBackend
 
     void HttpRideServer::createServerMethods()
     {
+        server_->Get("/", [this](const httplib::Request &, httplib::Response &res)
+                    {
+                        respondJson(res,
+                                    json{{"status", "ok"},
+                                         {"service", "RideManager"},
+                                         {"message", "Ride Manager HTTP interface is running"}});
+                    });
+
         server_->Post("/rides/request", [this](const httplib::Request &req, httplib::Response &res)
                       {
                           auto payload = parseJsonBody(req, res);

--- a/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
+++ b/UserManager/src/services/httpHandler/Servers/httpUserServer.cpp
@@ -76,6 +76,14 @@ void HttpUserServer::createServerMethods()
         }
     };
 
+    server_->Get("/", [respondJson](const httplib::Request &, httplib::Response &res)
+    {
+        respondJson(res,
+                    json{{"status", "ok"},
+                         {"service", "UserManager"},
+                         {"message", "User Manager HTTP interface is running"}});
+    });
+
     server_->Post("/login", [this, respondJson, parseBody](const httplib::Request &req, httplib::Response &res)
     {
         auto jsonDataOpt = parseBody(req, res);


### PR DESCRIPTION
## Summary
- add a JSON status response on the root path of the RideManager HTTP server
- provide the same root status endpoint for the UserManager and LocationManager services

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8789e24ec8333bf45a6eca418eb4d