### PR TITLE
Create marketing pages for home, pricing, and invoice preview

### DIFF
--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MobilityOS — Seamless Fleet & Ride Solutions</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body id="home">
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">MobilityOS</a>
+        <nav aria-label="Primary Navigation">
+          <ul>
+            <li><a class="active" href="#home">Home</a></li>
+            <li><a href="#features">Features</a></li>
+            <li><a href="#team">Team</a></li>
+            <li><a href="pricing.html">Pricing</a></li>
+            <li><a href="invoice-template.html">Invoice Template</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <h1 id="hero-title">Orchestrate world-class ride experiences in minutes</h1>
+        <p>
+          MobilityOS connects dispatching, dynamic pricing, and billing into a single
+          control center. Launch new geographies, manage hybrid fleets, and reward
+          drivers with effortless workflows.
+        </p>
+        <div class="btn-group">
+          <a class="btn primary" href="pricing.html">See pricing</a>
+          <a class="btn secondary" href="team.html">Meet the team</a>
+        </div>
+      </section>
+
+      <section class="section" id="features" aria-labelledby="feature-heading">
+        <div class="container">
+          <h2 id="feature-heading">Why teams ship faster with MobilityOS</h2>
+          <p class="section-intro">
+            From passenger onboarding to automated invoicing, every microservice is
+            production-ready and backed by compliance tooling.
+          </p>
+          <div class="features-grid">
+            <article class="feature-card">
+              <h3>Unified command center</h3>
+              <p>
+                Monitor live driver status, rider ETAs, and surge multipliers on a
+                real-time dashboard that scales across continents.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Usage-based billing</h3>
+              <p>
+                Generate branded invoices, schedule payouts, and surface taxes in a
+                transparent and auditable workflow.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Compliance automation</h3>
+              <p>
+                Pre-built regional templates keep every trip compliant with mobility
+                regulations and mobility-as-a-service requirements.
+              </p>
+            </article>
+            <article class="feature-card">
+              <h3>Developer friendly APIs</h3>
+              <p>
+                Launch new integrations quickly with our gRPC and REST SDKs, complete
+                with sandbox credentials and lifecycle hooks.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="team" aria-labelledby="team-heading">
+        <div class="container">
+          <h2 id="team-heading">The team accelerating modern mobility</h2>
+          <p class="section-intro">
+            Product strategists, mobility engineers, and operations veterans working
+            together to deliver delightful rider experiences at scale.
+          </p>
+          <div class="team-grid">
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=12" alt="Portrait of Ava Patel" />
+              <h3>Ava Patel</h3>
+              <span>Head of Platform</span>
+              <p>
+                Leads our platform architecture, ensuring reliability and quick
+                iterations across all mobility services.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=32" alt="Portrait of Noah Williams" />
+              <h3>Noah Williams</h3>
+              <span>Pricing Intelligence Lead</span>
+              <p>
+                Crafts the dynamic pricing models that balance driver earnings and
+                rider satisfaction in peak demand windows.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=47" alt="Portrait of Mei Chen" />
+              <h3>Mei Chen</h3>
+              <span>Compliance &amp; Finance</span>
+              <p>
+                Oversees regulatory coverage, audit-ready invoicing, and geo-specific
+                tax engines for multi-region fleets.
+              </p>
+            </article>
+          </div>
+          <div style="text-align: center; margin-top: 2.5rem;">
+            <a class="btn secondary" href="team.html">Meet the full crew</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      Crafted with empathy for mobility teams. Need a custom deployment?
+      <a href="mailto:hello@mobilityos.dev">hello@mobilityos.dev</a>
+    </footer>
+  </body>
+</html>

--- a/docs/website/invoice-template.html
+++ b/docs/website/invoice-template.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MobilityOS Invoice — Preview</title>
+    <link rel="stylesheet" href="invoice.css" />
+  </head>
+  <body>
+    <div class="invoice-wrapper">
+      <header class="invoice-header">
+        <div class="invoice-brand">
+          <h1>INVOICE</h1>
+          <span>crafted with mobilityos</span>
+        </div>
+        <div class="invoice-meta">
+          <strong>Invoice #</strong>
+          <span class="meta-id">INV-000807</span>
+          <p><strong>Amount Due:</strong> $870.00</p>
+          <p>Issued: 28/09/2025</p>
+          <p>Due: 12/10/2025</p>
+        </div>
+      </header>
+
+      <section class="invoice-details">
+        <div class="detail-block">
+          <h2>Bill To</h2>
+          <p><strong>Kathasyaake Pty Ltd</strong></p>
+          <p>02/44 Porter Street</p>
+          <p>Chadstone VIC 3148</p>
+          <p>Australia</p>
+          <p>rams.rath@gmail.com</p>
+        </div>
+        <div class="detail-block">
+          <h2>Issued By</h2>
+          <p><strong>MobilityOS</strong></p>
+          <p>120 Market Street</p>
+          <p>San Francisco, CA 94105</p>
+          <p>+1 (415) 555-2048</p>
+          <p>billing@mobilityos.dev</p>
+        </div>
+        <div class="detail-block">
+          <h2>Project</h2>
+          <p><strong>Technical Support &amp; Dispatch Advisory</strong></p>
+          <p>Billing Period: September 2025</p>
+          <p>Payment Terms: Net 14</p>
+          <p>Bank Ref: MOB-294502</p>
+        </div>
+      </section>
+
+      <table class="invoice-table" aria-label="Invoice line items">
+        <thead>
+          <tr>
+            <th scope="col">#</th>
+            <th scope="col">Item &amp; Description</th>
+            <th scope="col">Qty</th>
+            <th scope="col">Rate</th>
+            <th scope="col">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>001</td>
+            <td>
+              Technical Support Retainer
+              <div class="line-description">
+                Dedicated senior engineer support and release readiness reviews.
+              </div>
+            </td>
+            <td>12 hrs</td>
+            <td>$70.00</td>
+            <td>$840.00</td>
+          </tr>
+          <tr>
+            <td>002</td>
+            <td>
+              Platform Diagnostics
+              <div class="line-description">
+                Comprehensive fleet diagnostics, uptime checks, and QA validation.
+              </div>
+            </td>
+            <td>2 hrs</td>
+            <td>$15.00</td>
+            <td>$30.00</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="invoice-summary">
+        <table aria-label="Invoice totals">
+          <tr>
+            <td>Subtotal</td>
+            <td style="text-align: right;">$870.00</td>
+          </tr>
+          <tr>
+            <td>Tax (0%)</td>
+            <td style="text-align: right;">$0.00</td>
+          </tr>
+          <tr>
+            <td>Amount Paid</td>
+            <td style="text-align: right;">$0.00</td>
+          </tr>
+          <tr class="total-row">
+            <td>Total Due</td>
+            <td style="text-align: right;">$870.00</td>
+          </tr>
+        </table>
+      </div>
+
+      <section class="invoice-notes">
+        <div class="notes-block">
+          <h3>Notes</h3>
+          <p>Thank you for trusting MobilityOS to power your rider experience.</p>
+          <p>Have questions? Reach out to your engagement manager.</p>
+        </div>
+        <div class="notes-block">
+          <h3>Payment</h3>
+          <p>Payment is due within 14 days of the invoice date.</p>
+          <div class="payment-options">
+            Payment Options:
+            <span>Bank Transfer</span>
+            <span>PayPal</span>
+            <span>Card</span>
+          </div>
+        </div>
+      </section>
+
+      <p class="invoice-footer">
+        Crafted with ease using MobilityOS invoices. Visit
+        <a href="https://mobilityos.dev">mobilityos.dev</a> to create professionally
+        branded invoices.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/website/invoice.css
+++ b/docs/website/invoice.css
@@ -1,0 +1,236 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Roboto+Mono:wght@400;500&display=swap');
+
+:root {
+  --slate: #1f2933;
+  --teal: #1c9c8c;
+  --muted: #52606d;
+  --border: #e4e7eb;
+  --background: #f1f4f8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 2.5rem 0;
+  background: var(--background);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--slate);
+}
+
+.invoice-wrapper {
+  background: white;
+  width: min(900px, 92%);
+  margin: 0 auto;
+  padding: 2.5rem 3rem;
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+.invoice-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  border-bottom: 2px solid var(--border);
+  padding-bottom: 1.75rem;
+}
+
+.invoice-brand h1 {
+  margin: 0;
+  font-size: 2.25rem;
+  letter-spacing: 0.08em;
+}
+
+.invoice-brand span {
+  display: inline-block;
+  margin-top: 0.35rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.invoice-meta {
+  text-align: right;
+}
+
+.invoice-meta p {
+  margin: 0.2rem 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.invoice-meta strong {
+  display: block;
+  font-size: 1.05rem;
+  color: var(--slate);
+}
+
+.meta-id {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: var(--slate);
+}
+
+.invoice-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  padding: 2rem 0;
+  border-bottom: 2px solid var(--border);
+}
+
+.detail-block h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.detail-block p {
+  margin: 0.35rem 0;
+  font-size: 0.98rem;
+}
+
+.detail-block p strong {
+  color: var(--slate);
+}
+
+.invoice-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0 1.5rem;
+  font-size: 0.97rem;
+}
+
+.invoice-table thead {
+  background: #f8fafc;
+}
+
+.invoice-table th,
+.invoice-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.invoice-table th {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.invoice-table td:first-child {
+  font-family: 'Roboto Mono', monospace;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.invoice-table td:nth-child(3),
+.invoice-table td:nth-child(4),
+.invoice-table td:nth-child(5) {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.line-description {
+  color: var(--muted);
+  font-size: 0.88rem;
+  margin-top: 0.3rem;
+}
+
+.invoice-summary {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.invoice-summary table {
+  width: 320px;
+  border-collapse: collapse;
+}
+
+.invoice-summary td {
+  padding: 0.4rem 0;
+  font-size: 0.98rem;
+}
+
+.invoice-summary td:first-child {
+  color: var(--muted);
+}
+
+.invoice-summary tr.total-row td {
+  padding-top: 0.8rem;
+  border-top: 2px solid var(--border);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--slate);
+}
+
+.invoice-notes {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px dashed var(--border);
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.notes-block h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.notes-block p {
+  margin: 0.3rem 0;
+  font-size: 0.95rem;
+}
+
+.payment-options {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.payment-options span {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+
+.invoice-footer {
+  margin-top: 2.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.invoice-footer a {
+  color: var(--teal);
+  text-decoration: none;
+}
+
+@media print {
+  body {
+    background: white;
+    padding: 0;
+  }
+
+  .invoice-wrapper {
+    width: 100%;
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+}

--- a/docs/website/pricing.html
+++ b/docs/website/pricing.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MobilityOS Pricing — Plans for every fleet size</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">MobilityOS</a>
+        <nav aria-label="Primary Navigation">
+          <ul>
+            <li><a href="index.html#home">Home</a></li>
+            <li><a href="index.html#features">Features</a></li>
+            <li><a href="team.html">Team</a></li>
+            <li><a class="active" href="pricing.html">Pricing</a></li>
+            <li><a href="invoice-template.html">Invoice Template</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="padding-bottom: 3rem;" aria-labelledby="pricing-hero">
+        <h1 id="pricing-hero">Pricing built around transparent growth</h1>
+        <p>
+          Choose the plan that meets your fleet goals. Every subscription includes
+          full access to mobility compliance, analytics, and billing automation.
+        </p>
+        <div class="btn-group">
+          <a class="btn primary" href="#plans">Compare plans</a>
+          <a class="btn secondary" href="invoice-template.html">Preview invoice</a>
+        </div>
+      </section>
+
+      <section class="section" id="plans" aria-labelledby="plan-heading">
+        <div class="container">
+          <h2 id="plan-heading">Simple, scalable pricing</h2>
+          <p class="section-intro">
+            Each plan includes 24/7 support, SOC 2 compliant infrastructure, and per
+            market localization tooling.
+          </p>
+          <div class="pricing-grid">
+            <article class="pricing-card">
+              <h3>Launch</h3>
+              <p class="price">$249<span style="font-size: 1rem;">/mo</span></p>
+              <ul>
+                <li>Up to 500 monthly trips</li>
+                <li>Driver onboarding workflows</li>
+                <li>Email-based support</li>
+              </ul>
+              <a class="btn secondary" href="#">Start trial</a>
+            </article>
+            <article class="pricing-card highlight">
+              <h3>Growth</h3>
+              <p class="price">$599<span style="font-size: 1rem;">/mo</span></p>
+              <ul>
+                <li>Unlimited trips &amp; dynamic pricing</li>
+                <li>Advanced analytics dashboards</li>
+                <li>Dedicated success manager</li>
+              </ul>
+              <a class="btn primary" href="#">Talk to sales</a>
+            </article>
+            <article class="pricing-card">
+              <h3>Enterprise</h3>
+              <p class="price">Let’s talk</p>
+              <ul>
+                <li>Custom compliance workflows</li>
+                <li>Multi-region settlement</li>
+                <li>Private roadmap alignment</li>
+              </ul>
+              <a class="btn secondary" href="#">Book a workshop</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="invoice-heading">
+        <div class="container">
+          <h2 id="invoice-heading">Invoice preview</h2>
+          <p class="section-intro">
+            Itemized charges appear on the left for quick scanning, while payment
+            details and totals live in a focused summary column.
+          </p>
+          <div class="invoice-layout">
+            <article class="invoice-table" aria-label="Invoice line items">
+              <h3 style="margin-top: 0;">Line items</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Item &amp; Description</th>
+                    <th scope="col">Qty</th>
+                    <th scope="col">Rate</th>
+                    <th scope="col">Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>01</td>
+                    <td>
+                      Dispatch Optimization
+                      <div style="color: var(--muted); font-size: 0.85rem;">
+                        Automated rider-driver matching algorithms
+                      </div>
+                    </td>
+                    <td>1</td>
+                    <td>$450.00</td>
+                    <td>$450.00</td>
+                  </tr>
+                  <tr>
+                    <td>02</td>
+                    <td>
+                      Compliance Toolkit
+                      <div style="color: var(--muted); font-size: 0.85rem;">
+                        Regional tax reporting + document storage
+                      </div>
+                    </td>
+                    <td>1</td>
+                    <td>$220.00</td>
+                    <td>$220.00</td>
+                  </tr>
+                  <tr>
+                    <td>03</td>
+                    <td>
+                      Analytics Workspace
+                      <div style="color: var(--muted); font-size: 0.85rem;">
+                        Real-time KPIs and anomaly detection dashboards
+                      </div>
+                    </td>
+                    <td>1</td>
+                    <td>$130.00</td>
+                    <td>$130.00</td>
+                  </tr>
+                </tbody>
+              </table>
+            </article>
+            <aside class="invoice-totals" aria-label="Invoice summary">
+              <h3>Billing summary</h3>
+              <dl>
+                <dt>Subtotal</dt>
+                <dd>$800.00</dd>
+                <dt>Mobility tax (8%)</dt>
+                <dd>$64.00</dd>
+                <dt>Credits applied</dt>
+                <dd>-$50.00</dd>
+                <dt>Total</dt>
+                <dd>$814.00</dd>
+              </dl>
+              <p style="color: var(--muted); font-size: 0.92rem;">
+                Payment is due within 14 days. Pay securely via bank transfer or card.
+              </p>
+              <a class="btn primary" href="invoice-template.html">Download PDF</a>
+            </aside>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      Need a custom quote? Email <a href="mailto:pricing@mobilityos.dev">pricing@mobilityos.dev</a>
+    </footer>
+  </body>
+</html>

--- a/docs/website/styles.css
+++ b/docs/website/styles.css
@@ -1,0 +1,362 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --primary: #2c3e50;
+  --accent: #18bc9c;
+  --muted: #6c7a89;
+  --bg-light: #f5f7fb;
+  --border: #e0e6ed;
+  --radius: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1a1f36;
+  background: var(--bg-light);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid var(--border);
+}
+
+header .nav-container {
+  width: min(1100px, 92%);
+  margin: 0 auto;
+  padding: 1rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--primary);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 500;
+  color: var(--muted);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+nav a.active,
+nav a:hover {
+  color: var(--accent);
+}
+
+.hero {
+  padding: 6rem 0 5rem;
+  width: min(1100px, 92%);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin-bottom: 1rem;
+  color: var(--primary);
+}
+
+.hero p {
+  max-width: 640px;
+  margin: 0.5rem auto 2rem;
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.btn-group {
+  display: inline-flex;
+  gap: 1rem;
+}
+
+.btn {
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 12px 24px rgba(24, 188, 156, 0.18);
+}
+
+.btn.secondary {
+  border-color: var(--border);
+  color: var(--primary);
+  background: white;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(27, 39, 51, 0.12);
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section .container {
+  width: min(1100px, 92%);
+  margin: 0 auto;
+}
+
+.section h2 {
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  margin-bottom: 0.75rem;
+  color: var(--primary);
+  text-align: center;
+}
+
+.section > .section-intro {
+  max-width: 640px;
+  margin: 0 auto 3rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+}
+
+.feature-card {
+  background: white;
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 35px rgba(31, 37, 50, 0.08);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  color: var(--primary);
+  font-size: 1.1rem;
+}
+
+.feature-card p {
+  color: var(--muted);
+  margin-bottom: 0;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+.team-card {
+  background: white;
+  padding: 2rem 1.5rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  text-align: center;
+  box-shadow: 0 16px 32px rgba(44, 62, 80, 0.08);
+}
+
+.team-card img {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1rem;
+  border: 4px solid rgba(24, 188, 156, 0.2);
+}
+
+.team-card h3 {
+  margin: 0.3rem 0 0.4rem;
+  color: var(--primary);
+}
+
+.team-card span {
+  display: inline-block;
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.team-card p {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.pricing-card {
+  background: white;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 2rem 1.75rem;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 18px 35px rgba(31, 37, 50, 0.08);
+}
+
+.pricing-card.highlight {
+  border-color: var(--accent);
+  transform: translateY(-6px);
+}
+
+.pricing-card h3 {
+  margin-top: 0;
+}
+
+.pricing-card .price {
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin: 0.6rem 0 1.2rem;
+  color: var(--primary);
+}
+
+.pricing-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+}
+
+.pricing-card li {
+  margin-bottom: 0.6rem;
+}
+
+.invoice-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1.2fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.invoice-table {
+  background: white;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  box-shadow: 0 18px 35px rgba(44, 62, 80, 0.08);
+}
+
+.invoice-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.invoice-table thead {
+  background: rgba(44, 62, 80, 0.06);
+}
+
+.invoice-table th,
+.invoice-table td {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.invoice-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.invoice-totals {
+  background: white;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  box-shadow: 0 18px 35px rgba(44, 62, 80, 0.08);
+}
+
+.invoice-totals h3 {
+  margin-top: 0;
+  color: var(--primary);
+}
+
+.invoice-totals dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem 1.25rem;
+  margin: 1rem 0;
+}
+
+.invoice-totals dt {
+  color: var(--muted);
+}
+
+.invoice-totals dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.footer {
+  padding: 2rem 0 3rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 860px) {
+  .invoice-layout {
+    grid-template-columns: 1fr;
+  }
+
+  header .nav-container {
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 4.5rem 0 3.5rem;
+  }
+
+  .btn-group {
+    flex-direction: column;
+  }
+}

--- a/docs/website/team.html
+++ b/docs/website/team.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MobilityOS Team — Mobility experts behind the platform</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="nav-container">
+        <a class="logo" href="index.html">MobilityOS</a>
+        <nav aria-label="Primary Navigation">
+          <ul>
+            <li><a href="index.html#home">Home</a></li>
+            <li><a href="index.html#features">Features</a></li>
+            <li><a class="active" href="team.html">Team</a></li>
+            <li><a href="pricing.html">Pricing</a></li>
+            <li><a href="invoice-template.html">Invoice Template</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="padding-bottom: 3rem;" aria-labelledby="team-hero">
+        <h1 id="team-hero">Meet the creators powering every ride</h1>
+        <p>
+          Designers, engineers, and operators collaborating across timezones to
+          deliver dependable rider and driver journeys.
+        </p>
+        <div class="btn-group">
+          <a class="btn primary" href="index.html#home">Back to home</a>
+          <a class="btn secondary" href="pricing.html">View pricing</a>
+        </div>
+      </section>
+
+      <section class="section" aria-label="Team members">
+        <div class="container">
+          <div class="team-grid">
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=11" alt="Portrait of Laila Hassan" />
+              <h3>Laila Hassan</h3>
+              <span>Chief Experience Officer</span>
+              <p>
+                Translates research into rider-first experiences and nurtures an
+                inclusive, mission-driven product culture.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=27" alt="Portrait of Marco Silva" />
+              <h3>Marco Silva</h3>
+              <span>Staff Mobility Engineer</span>
+              <p>
+                Builds low-latency dispatch systems backed by resilient microservices
+                and precise geospatial indexing.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=41" alt="Portrait of Priya Natarajan" />
+              <h3>Priya Natarajan</h3>
+              <span>Head of Revenue Ops</span>
+              <p>
+                Partners with finance teams to launch new markets and streamline
+                payouts with tax-compliant invoicing.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=50" alt="Portrait of Ben Castillo" />
+              <h3>Ben Castillo</h3>
+              <span>Director of Driver Success</span>
+              <p>
+                Champions driver growth programs with personalized incentives and
+                real-time fleet health dashboards.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=22" alt="Portrait of Sofia Alvarez" />
+              <h3>Sofia Alvarez</h3>
+              <span>Senior Product Strategist</span>
+              <p>
+                Coordinates roadmap alignment between regional mobility partners and
+                our platform squads.
+              </p>
+            </article>
+            <article class="team-card">
+              <img src="https://i.pravatar.cc/150?img=5" alt="Portrait of Daniel Adeyemi" />
+              <h3>Daniel Adeyemi</h3>
+              <span>Data Platform Lead</span>
+              <p>
+                Delivers forecasting and anomaly detection pipelines that keep ride
+                ETAs accurate across peak demand.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      Let’s co-create the future of mobility. Contact us at
+      <a href="mailto:hello@mobilityos.dev">hello@mobilityos.dev</a>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a lightweight marketing site under docs/website with a refreshed home page and dedicated team view
- reorganize the pricing page so the invoice line items read in a left-aligned table with a compact totals column
- craft a printable invoice template with structured billing metadata and polished styling that mirrors the provided reference

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d8be5d508c83338dd97ba61417ec36